### PR TITLE
Update GitHub Actions workflow with proper permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish:
     # Only run if PR was merged and had the 'release' label
@@ -15,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -34,8 +39,8 @@ jobs:
       
       - name: Create and push tag
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git tag -a "v$VERSION" -m "Release version $VERSION"
           git push origin "v$VERSION"
       


### PR DESCRIPTION
Add necessary permissions for GitHub Actions to create and push tags during releases.