### PR TITLE
Streaming metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ build/
 .eggs/
 
 data/
+ideas.txt


### PR DESCRIPTION
This pull request introduces several changes to improve metrics tracking in the `Agent`'s streaming mode. The key updates include adding new tests for metrics tracking, modifying the `Agent` class to track and report metrics, and ensuring that the metrics are correctly included in the messages.

### Metrics Tracking Enhancements:

* **New Tests for Metrics Tracking:**
  * Added `test_go_stream_metrics_tracking` to verify that metrics are properly tracked in streaming mode.
  * Added `test_go_stream_tool_metrics` to ensure tool execution metrics are tracked in streaming mode.
  * Added `test_go_stream_multiple_messages_metrics` to test metrics tracking across multiple messages in streaming mode.

* **Modifications to `Agent` Class:**
  * Added tracking of API call start time and current weave call in `go_stream` method.
  * Included metrics in the assistant message, such as model name, timing, usage, and weave call details.
  * Added tool execution time tracking and included metrics in the tool message.
  * Ensured that metrics are included in the final message when the maximum tool iteration count is reached.

### Minor Changes:

* Changed the model name from "gpt-4" to "gpt-4o" in the `mock_litellm` function.