### PR TITLE
Files in tool response messages

### DIFF
--- a/tests/tools/test_audio.py
+++ b/tests/tools/test_audio.py
@@ -74,12 +74,6 @@ async def test_text_to_speech_success(mock_speech_response, mock_audio_bytes):
         assert content["success"] is True
         assert "description" in content
         assert "Speech generated from text: 'Hello, this is a test.'" == content["description"]
-        assert "details" in content
-        assert content["details"]["filename"] == "speech_test_uuid_hex.mp3"
-        assert content["details"]["voice"] == "alloy"
-        assert content["details"]["model"] == "tts-1"
-        assert content["details"]["format"] == "mp3"
-        assert content["details"]["speed"] == 1.0
         
         # Check files list
         assert isinstance(files, list)
@@ -89,6 +83,14 @@ async def test_text_to_speech_success(mock_speech_response, mock_audio_bytes):
         assert file_info["filename"] == "speech_test_uuid_hex.mp3"
         assert file_info["mime_type"] == "audio/mpeg"
         assert file_info["description"] == "Speech generated from text: 'Hello, this is a test.'"
+        
+        # Check details moved to file attributes
+        assert "attributes" in file_info
+        assert file_info["attributes"]["voice"] == "alloy"
+        assert file_info["attributes"]["model"] == "tts-1"
+        assert file_info["attributes"]["format"] == "mp3"
+        assert file_info["attributes"]["speed"] == 1.0
+        assert file_info["attributes"]["text_length"] == len("Hello, this is a test.")
 
 @pytest.mark.asyncio
 async def test_text_to_speech_invalid_voice():

--- a/tests/tools/test_image.py
+++ b/tests/tools/test_image.py
@@ -64,9 +64,6 @@ async def test_generate_image_success(mock_image_response, mock_image_bytes):
         assert isinstance(content, dict)
         assert content["success"] is True
         assert content["description"] == mock_image_response["data"][0]["revised_prompt"]
-        assert "details" in content
-        assert isinstance(content["details"], dict)
-        assert content["details"]["filename"] == f"generated_image_{mock_image_response['created']}.png"
         
         # Check files list
         assert isinstance(files, list)
@@ -76,6 +73,15 @@ async def test_generate_image_success(mock_image_response, mock_image_bytes):
         assert file_info["filename"] == f"generated_image_{mock_image_response['created']}.png"
         assert file_info["mime_type"] == "image/png"
         assert file_info["description"] == mock_image_response["data"][0]["revised_prompt"]
+        
+        # Check details moved to file attributes
+        assert "attributes" in file_info
+        assert file_info["attributes"]["size"] == "1024x1024"
+        assert file_info["attributes"]["quality"] == "standard"
+        assert file_info["attributes"]["style"] == "vivid"
+        assert file_info["attributes"]["created"] == mock_image_response["created"]
+        assert file_info["attributes"]["prompt"] == "test image"
+        assert file_info["attributes"]["model"] == "dall-e-3"
 
 @pytest.mark.asyncio
 async def test_generate_image_error():
@@ -130,16 +136,23 @@ async def test_generate_image_parameters(mock_image_response, mock_image_bytes):
             response_format="url"
         )
         
-        # Check content details
+        # Check content
         content, files = result
         assert content["success"] is True
-        assert content["details"]["size"] == "1024x1024"
-        assert content["details"]["quality"] == "hd"
-        assert content["details"]["style"] == "natural"
         
         # Check file was generated
         assert len(files) == 1
-        assert files[0]["mime_type"] == "image/png"
+        file_info = files[0]
+        assert file_info["mime_type"] == "image/png"
+        
+        # Check details moved to file attributes
+        assert "attributes" in file_info
+        assert file_info["attributes"]["size"] == "1024x1024"
+        assert file_info["attributes"]["quality"] == "hd"
+        assert file_info["attributes"]["style"] == "natural"
+        assert file_info["attributes"]["created"] == mock_image_response["created"]
+        assert file_info["attributes"]["prompt"] == "test image"
+        assert file_info["attributes"]["model"] == "dall-e-3"
 
 @pytest.mark.asyncio
 async def test_generate_image_no_data():

--- a/tyler/models/agent.py
+++ b/tyler/models/agent.py
@@ -73,6 +73,23 @@ Assistant: "Let me figure that out for you."
 [Then you would use the calculator tool]
 
 Remember: ALWAYS write a brief, conversational message to the user BEFORE using any tools. Never skip this step. The message should acknowledge what the user is asking for and let them know what you're going to do, but keep it casual and friendly.
+
+**HANDLING FILE ATTACHMENTS:**
+
+Both user messages and tool responses may contain file attachments. 
+
+File attachments are included in the message content in this format:
+```
+[File: files/path/to/file.ext (mime/type)]
+```
+
+When referencing files in your responses, ALWAYS use the exact file path as shown in the file reference. For example:
+
+Instead of: "I've created an audio summary. You can listen to it [here](sandbox:/mnt/data/speech_ef3b8be3a702416494d9f20593d4b38f.mp3)."
+
+Use: "I've created an audio summary. You can listen to it [here](files/path/to/stored/file.mp3)."
+
+This ensures the user can access the file correctly.
 """)
 
     @weave.op()

--- a/tyler/models/attachment.py
+++ b/tyler/models/attachment.py
@@ -4,6 +4,7 @@ import base64
 import io
 import magic
 from tyler.utils.logging import get_logger
+from pathlib import Path
 
 # Get configured logger
 logger = get_logger(__name__)
@@ -245,6 +246,12 @@ class Attachment(BaseModel):
                 self.storage_backend = result['storage_backend']
                 self.storage_path = result['storage_path']
                 self.status = "stored"
+                
+                # Update filename to match the one created by the file store
+                # Extract the actual filename from the storage path
+                new_filename = Path(self.storage_path).name
+                logger.debug(f"Updating attachment filename from {self.filename} to {new_filename}")
+                self.filename = new_filename
                 
                 # Add storage info to attributes
                 self.attributes["storage_path"] = self.storage_path

--- a/tyler/models/attachment.py
+++ b/tyler/models/attachment.py
@@ -92,8 +92,16 @@ class Attachment(BaseModel):
         if self.storage_path:
             if not self.processed_content:
                 self.processed_content = {}
-            self.processed_content["url"] = f"/files/{self.storage_path}"
-            logger.debug(f"Updated processed_content with URL: {self.processed_content['url']}")
+            
+            try:
+                # Get the file URL from FileStore
+                from tyler.storage.file_store import FileStore
+                self.processed_content["url"] = FileStore.get_file_url(self.storage_path)
+                logger.debug(f"Updated processed_content with URL: {self.processed_content['url']}")
+            except Exception as e:
+                # Log the error but don't fail - the URL will be missing but that's better than crashing
+                logger.error(f"Failed to construct URL for attachment: {e}")
+                self.processed_content["error"] = f"Failed to construct URL: {str(e)}"
 
     async def process_and_store(self, force: bool = False) -> None:
         """Process the attachment content and store it in the file store."""

--- a/tyler/models/message.py
+++ b/tyler/models/message.py
@@ -208,15 +208,17 @@ class Message(BaseModel):
                 attachment_dict = {
                     "filename": attachment.filename,
                     "mime_type": attachment.mime_type,
+                    "file_id": attachment.file_id,
+                    "storage_path": attachment.storage_path,
+                    "storage_backend": attachment.storage_backend,
+                    "status": attachment.status
                 }
-                if attachment.processed_content:
-                    attachment_dict["processed_content"] = attachment.processed_content
-                # Only include content if it's already a string (base64)
-                if isinstance(attachment.content, str):
-                    attachment_dict["content"] = attachment.content
-                elif isinstance(attachment.content, bytes):
-                    # Convert bytes to base64 if needed
-                    attachment_dict["content"] = base64.b64encode(attachment.content).decode('utf-8')
+                
+                # Add processed content if available
+                if attachment.attributes:
+                    attachment_dict["attributes"] = attachment.attributes
+                
+                # Add to attachments list
                 message_dict["attachments"].append(attachment_dict)
             
         return message_dict
@@ -248,10 +250,11 @@ class Message(BaseModel):
                 if not attachment.storage_path:
                     continue
                 
-                # Get the URL from processed_content if available, otherwise construct it
-                file_url = attachment.processed_content.get("url") if attachment.processed_content else None
-                if not file_url:
-                    # Get the file URL from FileStore
+                # Get the URL from attributes if available, otherwise construct it
+                file_url = attachment.attributes.get("url") if attachment.attributes else None
+                
+                if not file_url and attachment.storage_path:
+                    # Construct URL from storage path
                     file_url = FileStore.get_file_url(attachment.storage_path)
                 
                 # Simplified file reference format
@@ -317,39 +320,33 @@ class Message(BaseModel):
                     },
                     "attachments": [
                         {
-                            "filename": "document.pdf",
-                            "content": "base64_encoded_content_string",
+                            "filename": "example.txt",
+                            "mime_type": "text/plain",
+                            "attributes": {
+                                "type": "text",
+                                "text": "Example content",
+                                "url": "/files/example.txt"
+                            },
+                            "status": "stored"
+                        },
+                        {
+                            "filename": "example.pdf",
                             "mime_type": "application/pdf",
-                            "processed_content": {
+                            "attributes": {
                                 "type": "document",
-                                "text": "Extracted text content from PDF",
-                                "overview": "Brief summary of the document"
-                            }
+                                "text": "Extracted text from PDF",
+                                "url": "/files/example.pdf"
+                            },
+                            "status": "stored"
                         },
                         {
-                            "filename": "screenshot.png",
-                            "content": "base64_encoded_image_string",
-                            "mime_type": "image/png",
-                            "processed_content": {
+                            "filename": "example.jpg",
+                            "mime_type": "image/jpeg",
+                            "attributes": {
                                 "type": "image",
-                                "text": "OCR extracted text if applicable",
-                                "overview": "Description of image contents",
-                                "analysis": {
-                                    "objects": ["person", "desk", "computer"],
-                                    "text_detected": True,
-                                    "dominant_colors": ["blue", "white"]
-                                }
-                            }
-                        },
-                        {
-                            "filename": "data.json",
-                            "content": "eyJrZXkiOiAidmFsdWUifQ==",  # base64 of {"key": "value"}
-                            "mime_type": "application/json",
-                            "processed_content": {
-                                "type": "json",
-                                "overview": "JSON data structure containing key-value pairs",
-                                "parsed_content": {"key": "value"}
-                            }
+                                "url": "/files/example.jpg"
+                            },
+                            "status": "stored"
                         }
                     ],
                     "metrics": {

--- a/tyler/storage/file_store.py
+++ b/tyler/storage/file_store.py
@@ -420,3 +420,34 @@ class FileStore:
             header, encoded = self.content.split(",", 1)
             return base64.b64decode(encoded)
         return content
+
+    @classmethod
+    def get_base_path(cls) -> str:
+        """Get the base storage path from environment variable"""
+        env_path = os.getenv('TYLER_FILE_STORAGE_PATH')
+        if not env_path:
+            raise ValueError("TYLER_FILE_STORAGE_PATH environment variable is not set. This is required for file storage.")
+        return env_path
+        
+    @classmethod
+    def get_file_url(cls, relative_path: str) -> str:
+        """
+        Get the full URL for a file based on its relative path.
+        
+        Args:
+            relative_path: The path relative to the base storage path
+            
+        Returns:
+            The full URL for the file
+        """
+        # Get the base path
+        base_path = cls.get_base_path()
+        
+        # Construct the full URL by combining the base path and relative path
+        # Make sure there's exactly one slash between them
+        if base_path.endswith('/'):
+            base_path = base_path[:-1]
+        if relative_path.startswith('/'):
+            relative_path = relative_path[1:]
+            
+        return f"{base_path}/{relative_path}"

--- a/tyler/tools/audio.py
+++ b/tyler/tools/audio.py
@@ -100,20 +100,19 @@ async def text_to_speech(*,
             {
                 "success": True,
                 "description": description,
-                "details": {
-                    "filename": filename,
+            },
+            [{
+                "content": audio_bytes,  # Return raw bytes instead of base64 string
+                "filename": filename,
+                "mime_type": mime_type,
+                "description": description,
+                "attributes": {
                     "voice": voice,
                     "model": model,
                     "format": response_format,
                     "speed": speed,
                     "text_length": len(input)
                 }
-            },
-            [{
-                "content": audio_bytes,  # Return raw bytes instead of base64 string
-                "filename": filename,
-                "mime_type": mime_type,
-                "description": description
             }]
         )
 

--- a/tyler/tools/image.py
+++ b/tyler/tools/image.py
@@ -32,6 +32,7 @@ async def generate_image(*,
     try:
         # Validate size
         valid_sizes = ["1024x1024", "1792x1024", "1024x1792"]
+        model = "dall-e-3"
         if size not in valid_sizes:
             return (
                 {
@@ -43,7 +44,7 @@ async def generate_image(*,
 
         response = image_generation(
             prompt=prompt,
-            model="dall-e-3",
+            model=model,
             n=1,
             size=size,
             quality=quality,
@@ -89,19 +90,20 @@ async def generate_image(*,
             {
                 "success": True,
                 "description": description,
-                "details": {
-                    "filename": filename,
-                    "size": size,
-                    "quality": quality,
-                    "style": style,
-                    "created": response["created"]
-                }
             },
             [{
                 "content": base64_image,  # Now base64 encoded
                 "filename": filename,
                 "mime_type": "image/png",
-                "description": description
+                "description": description,
+                "attributes": {
+                    "size": size,
+                    "quality": quality,
+                    "style": style,
+                    "created": response["created"],
+                    "prompt": prompt,
+                    "model": model
+                }
             }]
         )
 


### PR DESCRIPTION
This pull request includes several changes to the `tests/models/test_attachment.py` and `tests/models/test_message.py` files to rename the `processed_content` attribute to `attributes`. Additionally, it includes modifications to the test cases to reflect this change and to add new test cases for enhanced functionality.

Here are the most important changes:

### Attribute Renaming:
* Renamed `processed_content` to `attributes` in the `sample_attachment` function and related test cases in `tests/models/test_attachment.py`. [[1]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L20-R20) [[2]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L45-R45) [[3]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L78-R78) [[4]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L93-R93)
* Updated the `update_processed_content_with_url` method to `update_attributes_with_url` and related test cases. [[1]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L170-R210) [[2]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L226-R249)
* Modified the `process` method to set `attributes` instead of `processed_content`. [[1]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L350-R353) [[2]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L402-R405) [[3]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L420-R423)

### Enhanced Test Cases:
* Added patches for `FileStore.get_file_url` in various test cases to mock the file URL retrieval. [[1]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L153-R154) [[2]](diffhunk://#diff-53afb5ef9e283ff12b6e74cb706e38b8f4c23c2926f93017f1dec000f2863003L442-R446) [[3]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdR197) [[4]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdR208-R231) [[5]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdR242-R255)
* Added a new test case `test_filename_update_after_storage` to verify that the filename is updated after storage.

### Updates to `test_message.py`:
* Renamed `processed_content` to `attributes` in the `test_message_serialization` function and related test cases in `tests/models/test_message.py`. [[1]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdL85-R85) [[2]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdL104-R104) [[3]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdL149-R149) [[4]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdL170-R170) [[5]](diffhunk://#diff-0c726e383d0e303ec728247b164fa92c62a7d0facd3b4cfbad222795afa066cdL182-R182)
* Updated the `test_message_with_error_attachments` function to reflect the renaming of `processed_content` to `attributes`.