### PR TITLE
Integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,40 @@ if __name__ == "__main__":
 
 See the complete examples in the documentation.
 
+## Running Examples and Tests
+
+Tyler comes with a variety of examples in the `examples/` directory that demonstrate different features and capabilities. These examples can also be run as integration tests to ensure everything is working correctly.
+
+### Running Examples as Tests
+
+The examples are integrated into the test suite with special markers to allow running them separately from unit tests:
+
+```bash
+# Run only the example tests
+pytest -m examples
+
+# Run only unit tests (excluding examples)
+pytest -k "not examples"
+
+# Run all tests (unit tests and examples)
+pytest
+```
+
+This separation is particularly useful during development, allowing you to run the faster unit tests while making changes, and run the full test suite including examples before committing.
+
+### Example Categories
+
+The examples directory includes demonstrations of:
+
+- Basic agent conversations
+- Using built-in and custom tools
+- Working with file attachments
+- Image and audio processing
+- Streaming responses
+- MCP (Model Context Protocol) integration
+
+Each example is a standalone Python script that can be run directly or as part of the test suite.
+
 ## License
 
 This project is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0) - see the [LICENSE](LICENSE) file for details.

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,4 +11,6 @@ python_classes = Test
 python_functions = test_*
 asyncio_mode = auto
 markers =
-    asyncio: mark a test as an async test 
+    asyncio: mark a test as an async test
+    examples: mark a test as an example integration test
+    integration: mark a test as an integration test 

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -20,8 +20,11 @@ def temp_db():
         url = f"sqlite+aiosqlite:///{f.name}"
         # Create a fresh database file
         engine = create_async_engine(url)
-        # Close any existing connections
-        engine.dispose()
+        # Close any existing connections - this needs to be awaited
+        # We'll use sync_engine instead since we're in a sync context
+        sync_url = url.replace("sqlite+aiosqlite://", "sqlite://")
+        sync_engine = create_engine(sync_url)
+        sync_engine.dispose()
         yield url
 
 @pytest.fixture

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -40,6 +40,8 @@ def run_example_main(module):
     return None
 
 
+@pytest.mark.examples  # Mark all example tests with 'examples' marker
+@pytest.mark.integration  # Also mark as integration tests
 @pytest.mark.parametrize("example_path", example_files)
 def test_example(example_path, monkeypatch):
     """Test that an example runs without errors."""

--- a/tyler/database/models.py
+++ b/tyler/database/models.py
@@ -1,6 +1,6 @@
 """Database models for SQLAlchemy"""
 from sqlalchemy import Column, String, JSON, DateTime, Text, ForeignKey, Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship
 from datetime import datetime, UTC
 

--- a/tyler/tools/image.py
+++ b/tyler/tools/image.py
@@ -75,7 +75,7 @@ async def generate_image(*,
         # Fetch the image bytes
         async with httpx.AsyncClient() as client:
             img_response = await client.get(image_url)
-            img_response.raise_for_status()
+            await img_response.raise_for_status()
             image_bytes = img_response.content
 
         # Create a unique filename based on timestamp


### PR DESCRIPTION
This pull request includes several changes to improve testing and fix issues related to asynchronous operations in the codebase. The most important changes include adding example tests, fixing asynchronous issues, and updating test markers.

### Improvements to testing:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R297-R330): Added a new section on running examples and tests, including commands for running example tests separately from unit tests.
* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R15-R16): Added new markers for example and integration tests to facilitate running different types of tests.

### Fixes to asynchronous operations:

* [`tests/database/test_migrations.py`](diffhunk://#diff-fc3bb80eaca8115e2a06defff5928a3edc6f85b91b63f25d3493e57e3dbf1173L23-R27): Fixed the `temp_db` fixture to properly dispose of the sync engine in a synchronous context.
* [`tests/mcp/test_server_manager.py`](diffhunk://#diff-4b12c57db1f0042331d471ee1516c7886bf3b562ab43b7fae438fc4b6a973aa9L143-R157): Updated `test_stop_server` and `test_stop_all_servers` to patch `asyncio.to_thread` and use `MagicMock` instead of `AsyncMock` for `wait` method to ensure proper handling of asynchronous operations. [[1]](diffhunk://#diff-4b12c57db1f0042331d471ee1516c7886bf3b562ab43b7fae438fc4b6a973aa9L143-R157) [[2]](diffhunk://#diff-4b12c57db1f0042331d471ee1516c7886bf3b562ab43b7fae438fc4b6a973aa9L207-R214) [[3]](diffhunk://#diff-4b12c57db1f0042331d471ee1516c7886bf3b562ab43b7fae438fc4b6a973aa9R226-R234)

### Additional changes:

* [`tests/test_examples.py`](diffhunk://#diff-0741a50beca4b08d354933485499f735f9b5493841e8f3af0e89b16ae1e04af4R43-R44): Marked example tests with `examples` and `integration` markers to categorize them appropriately.
* [`tyler/database/models.py`](diffhunk://#diff-38ef8593c0ce615afb804c2822431355e3eeb7e295a20e216ed202bfee248746L3-R3): Updated import to use `declarative_base` from `sqlalchemy.orm` instead of `sqlalchemy.ext.declarative`.
* [`tyler/tools/image.py`](diffhunk://#diff-3eb61ebfbf8a08c971c5d32cce1370b4e571b747abc8fa6b7ced47ac7d8c9bfaL78-R78): Added `await` to `img_response.raise_for_status()` to ensure proper asynchronous error handling.