### PR TITLE
add separater for content

### DIFF
--- a/tyler/tools/slack.py
+++ b/tyler/tools/slack.py
@@ -69,8 +69,9 @@ async def generate_slack_blocks(*, content: str) -> dict:
     """
     prompt = f"""
     Convert the following content into Slack blocks format:
-
+    ```
     {content}
+    ```
 
     IMPORTANT GUIDELINES:
     - Use ONLY official Slack block types: section, context, divider, image, actions, header, input, file, video, markdown


### PR DESCRIPTION
This pull request makes a small improvement to the `generate_slack_blocks` function in `tyler/tools/slack.py`. The change ensures that the input `content` is wrapped in triple backticks to indicate a code block in the generated Slack blocks format.