### PR TITLE
Reactions, imports, registry... honestly way to much for a single pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ While Tyler can be used as a library, it comes with two interactive interfaces:
 
 The central component that:
 - Manages conversations through threads
-- Processes messages using LLMs (GPT-4o by default)
+- Processes messages using LLMs (GPT-4.1 by default)
 - Executes tools when needed
 - Maintains conversation state
 - Supports streaming responses
@@ -263,7 +263,7 @@ load_dotenv()
 
 # Initialize the agent (uses in-memory storage by default)
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with general questions"
 )
 

--- a/README.md
+++ b/README.md
@@ -253,10 +253,8 @@ For a complete list of supported providers and models, see the [LiteLLM document
 This example uses in-memory storage which is perfect for scripts and testing. 
 
 ```python
-from dotenv import load_dotenv
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from dotenv import load_dotenv 
+from tyler import Agent, Thread, Message
 import asyncio
 import os
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,74 @@
+# Database Migrations in Tyler
+
+This document describes how to manage database migrations in Tyler.
+
+## Running Migrations
+
+When Tyler is updated, you may need to run database migrations to update your database schema. There are several ways to do this depending on how you installed Tyler.
+
+### Using the Tyler CLI (Recommended)
+
+If you installed Tyler through pip, pypi, or uv, you can use the built-in CLI command:
+
+```bash
+# Upgrade to latest version
+tyler db upgrade
+
+# Check current migration version
+tyler db current
+
+# View migration history
+tyler db history
+```
+
+### Using the Direct Database CLI
+
+Tyler also provides a dedicated database CLI:
+
+```bash
+tyler-db upgrade
+```
+
+### Using Programmatic API
+
+You can also run migrations from your Python code:
+
+```python
+import asyncio
+from alembic import command
+from tyler.database.cli import get_alembic_config
+
+async def run_migrations():
+    alembic_cfg = get_alembic_config()
+    command.upgrade(alembic_cfg, "head")
+
+# Run migrations
+asyncio.run(run_migrations())
+```
+
+## When to Run Migrations
+
+You should run migrations:
+
+1. After updating Tyler to a new version
+2. When instructed to in the release notes
+3. Before using new features that require database schema changes
+
+## Common Migration Commands
+
+| Command | Description |
+|---------|-------------|
+| `tyler db upgrade` | Update database to latest schema version |
+| `tyler db downgrade` | Downgrade database by one version |
+| `tyler db current` | Show current database version |
+| `tyler db history` | Show migration history |
+| `tyler db migrate` | Generate a new migration based on model changes (developer use) |
+
+## Troubleshooting
+
+If you encounter issues running migrations:
+
+1. Check your database connection settings
+2. Ensure you're using the latest version of Tyler
+3. Make sure your database user has sufficient permissions
+4. Check the logs for detailed error messages 

--- a/docs/docs/api-reference/agent.md
+++ b/docs/docs/api-reference/agent.md
@@ -9,7 +9,7 @@ The `Agent` class is the core component of Tyler, responsible for managing conve
 ## Initialization
 
 ```python
-from tyler.models.agent import Agent
+from tyler import Agent
 
 agent = Agent(
     model_name: str = "gpt-4o",
@@ -397,7 +397,7 @@ coordinator = Agent(
    agent = Agent()  # Uses in-memory store
    
    # For production
-   from tyler.database.thread_store import ThreadStore
+   from tyler import ThreadStore
    store = ThreadStore("postgresql://...")
    agent = Agent(thread_store=store)
    ```

--- a/docs/docs/api-reference/agent.md
+++ b/docs/docs/api-reference/agent.md
@@ -12,7 +12,7 @@ The `Agent` class is the core component of Tyler, responsible for managing conve
 from tyler import Agent
 
 agent = Agent(
-    model_name: str = "gpt-4o",
+    model_name: str = "gpt-4.1",
     temperature: float = 0.7,
     name: str = "Tyler",
     purpose: str = "To be a helpful assistant.",
@@ -29,7 +29,7 @@ agent = Agent(
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `model_name` | str | No | "gpt-4o" | The LLM model to use |
+| `model_name` | str | No | "gpt-4.1" | The LLM model to use |
 | `temperature` | float | No | 0.7 | Response creativity (0.0-1.0) |
 | `name` | str | No | "Tyler" | Name of the agent |
 | `purpose` | str | No | "To be a helpful assistant." | The agent's purpose or role |

--- a/docs/docs/api-reference/attachment.md
+++ b/docs/docs/api-reference/attachment.md
@@ -9,7 +9,7 @@ The `Attachment` class represents files attached to messages in Tyler. It handle
 ## Initialization
 
 ```python
-from tyler.models.attachment import Attachment
+from tyler import Attachment
 
 # Basic attachment
 attachment = Attachment(

--- a/docs/docs/api-reference/file-store.md
+++ b/docs/docs/api-reference/file-store.md
@@ -27,7 +27,7 @@ file_store = await FileStore.create()
 from tyler import Agent
 
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with tasks",
     thread_store=thread_store,
     file_store=file_store  # Explicitly pass file_store instance

--- a/docs/docs/api-reference/file-store.md
+++ b/docs/docs/api-reference/file-store.md
@@ -11,7 +11,7 @@ The `FileStore` class provides a unified interface for storing and retrieving fi
 ### Factory Pattern
 
 ```python
-from tyler.storage.file_store import FileStore
+from tyler import FileStore
 
 # Create a FileStore instance with factory pattern
 file_store = await FileStore.create(
@@ -24,7 +24,7 @@ file_store = await FileStore.create(
 file_store = await FileStore.create()
 
 # Pass the file_store to an Agent
-from tyler.models.agent import Agent
+from tyler import Agent
 
 agent = Agent(
     model_name="gpt-4o",
@@ -361,8 +361,7 @@ Path to the initialized storage directory.
 The `FileStore` class works seamlessly with the `Attachment` model:
 
 ```python
-from tyler.models.attachment import Attachment
-from tyler.storage.file_store import FileStore
+from tyler import Attachment, FileStore
 
 # Create a FileStore instance
 file_store = await FileStore.create()

--- a/docs/docs/api-reference/index.md
+++ b/docs/docs/api-reference/index.md
@@ -26,9 +26,7 @@ pip install tyler-agent
 Here's a quick example of using the core components:
 
 ```python
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 
 # Create an agent
 agent = Agent(

--- a/docs/docs/api-reference/index.md
+++ b/docs/docs/api-reference/index.md
@@ -30,7 +30,7 @@ from tyler import Agent, Thread, Message
 
 # Create an agent
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with tasks"
 )
 

--- a/docs/docs/api-reference/message.md
+++ b/docs/docs/api-reference/message.md
@@ -56,16 +56,11 @@ message = Message(
     role="user",
     content="Hello!",
     source={
-        "entity": {
-            "id": "U123456",
-            "name": "John Doe",
-            "type": "user"
-        },
-        "platform": {
-            "name": "slack",
-            "attributes": {
-                "thread_ts": "1234567890.123456"
-            }
+        "id": "U123456",
+        "name": "John Doe",
+        "type": "user",
+        "attributes": {
+            "email": "john@example.com"
         }
     },
     attributes={"customer_id": "456"}
@@ -85,7 +80,7 @@ message = Message(
 | `tool_calls` | Optional[list] | No | None | Tool calls (for assistant messages) |
 | `attributes` | Dict | No | {} | Custom metadata |
 | `timestamp` | datetime | No | now(UTC) | Message timestamp |
-| `source` | Optional[MessageSource] | No | None | Source information (see MessageSource structure) |
+| `source` | Optional[EntitySource] | No | None | Source information (see EntitySource structure below) |
 | `attachments` | List[Attachment] | No | [] | File attachments |
 | `metrics` | Dict[str, Any] | No | Default metrics | Message metrics and analytics |
 | `reactions` | Dict[str, List[str]] | No | {} | Map of emoji to list of user IDs who reacted |
@@ -93,20 +88,12 @@ message = Message(
 ### Source Structure
 
 ```python
-# TypedDict definitions for source structure
-class PlatformSource(TypedDict, total=False):
-    name: str  # Name of the platform (slack, discord, etc.)
-    attributes: Optional[Dict[str, Any]]  # Platform-specific attributes
-
+# TypedDict definition for source structure
 class EntitySource(TypedDict, total=False):
     id: str  # Unique identifier for the entity
     name: str  # Human-readable name of the entity
     type: Literal["user", "agent", "tool"]  # Type of entity
     attributes: Optional[Dict[str, Any]]  # All other entity-specific attributes
-
-class MessageSource(TypedDict, total=False):
-    entity: Optional[EntitySource]  # Information about the entity that created the message
-    platform: Optional[PlatformSource]  # Information about the platform where the message was created
 ```
 
 ### Content Types
@@ -620,22 +607,14 @@ Ensures the source field has the correct structure with valid entity type if pre
        role="user",
        content="Hello",
        source={
-           "entity": {
-               "id": "U123456",
-               "name": "John Doe",
-               "type": "user",
-               "attributes": {
-                   "email": "john@example.com"
-               }
-           },
-           "platform": {
-               "name": "slack",
-               "attributes": {
-                   "channel_id": "C123456",
-                   "thread_ts": "1234567890.123456"
-               }
+           "id": "U123456",
+           "name": "John Doe",
+           "type": "user",
+           "attributes": {
+               "email": "john@example.com"
            }
-       }
+       },
+       attributes={"customer_id": "456"}
    )
    ```
 

--- a/docs/docs/api-reference/message.md
+++ b/docs/docs/api-reference/message.md
@@ -9,7 +9,7 @@ The `Message` class represents individual interactions within a thread. It handl
 ## Initialization
 
 ```python
-from tyler.models.message import Message
+from tyler import Message
 from datetime import datetime, UTC
 
 # Basic text message

--- a/docs/docs/api-reference/message.md
+++ b/docs/docs/api-reference/message.md
@@ -599,7 +599,7 @@ Ensures the source field has the correct structure with valid entity type if pre
    ```python
    # Update metrics after processing
    message.metrics.update({
-       "model": "gpt-4o",
+       "model": "gpt-4.1",
        "timing": {
            "started_at": start_time,
            "ended_at": end_time,

--- a/docs/docs/api-reference/registry.md
+++ b/docs/docs/api-reference/registry.md
@@ -1,0 +1,225 @@
+---
+sidebar_position: 7
+---
+
+# Registry API
+
+The `tyler.utils.registry` module provides a centralized mechanism for managing shared instances of core components, primarily `ThreadStore` and `FileStore`. This allows different parts of an application, or multiple agent instances, to access the same store instances by a registered name, ensuring consistency and a single source of truth for storage operations.
+
+While the registry includes a generic `Registry` class, most users will interact with the specific helper functions provided for `ThreadStore` and `FileStore`.
+
+## Overview
+
+The registry helps in scenarios where you might have multiple store configurations (e.g., a default in-memory store for quick tasks and a persistent database store for long-term storage) or when you want to explicitly manage the lifecycle and accessibility of your store instances.
+
+Key benefits:
+-   **Named Instances**: Register stores with a unique name (e.g., "default", "persistent_db", "archive_files").
+-   **Global Access**: Retrieve registered stores from anywhere in your application using their name.
+-   **Agent Integration**: Agents can be configured to use stores from the registry by specifying their registered names via `agent.set_stores()`.
+
+## Core Functions
+
+These are the primary functions you'll use to interact with the registry for thread and file stores.
+
+### `register_thread_store`
+
+Registers a `ThreadStore` instance with a given name.
+
+```python
+def register_thread_store(name: str, thread_store: ThreadStore) -> ThreadStore
+```
+
+**Parameters:**
+
+| Parameter      | Type        | Description                         |
+| -------------- | ----------- | ----------------------------------- |
+| `name`         | `str`       | The name to register the store with. |
+| `thread_store` | `ThreadStore` | The `ThreadStore` instance to register. |
+
+**Returns:**
+
+The registered `ThreadStore` instance.
+
+**Example:**
+
+```python
+from tyler import ThreadStore
+from tyler.utils.registry import register_thread_store
+
+# Create a database-backed thread store
+db_thread_store = await ThreadStore.create("sqlite+aiosqlite:///./tyler_threads.db")
+
+# Register it with the name "persistent"
+register_thread_store("persistent", db_thread_store)
+
+# Create an in-memory thread store
+mem_thread_store = await ThreadStore.create()
+register_thread_store("default_memory", mem_thread_store)
+```
+
+### `get_thread_store`
+
+Retrieves a registered `ThreadStore` instance by its name.
+
+```python
+def get_thread_store(name: str) -> Optional[ThreadStore]
+```
+
+**Parameters:**
+
+| Parameter | Type  | Description                                  |
+| --------- | ----- | -------------------------------------------- |
+| `name`    | `str` | The name of the `ThreadStore` to retrieve. |
+
+**Returns:**
+
+The `ThreadStore` instance if found, otherwise `None`.
+
+**Example:**
+
+```python
+from tyler.utils.registry import get_thread_store
+
+persistent_store = get_thread_store("persistent")
+if persistent_store:
+    # Use the store
+    print(f"Retrieved persistent store: {type(persistent_store)}")
+
+default_store = get_thread_store("default_memory")
+if default_store:
+    print(f"Retrieved default memory store: {type(default_store)}")
+```
+
+### `register_file_store`
+
+Registers a `FileStore` instance with a given name.
+
+```python
+def register_file_store(name: str, file_store: FileStore) -> FileStore
+```
+
+**Parameters:**
+
+| Parameter    | Type      | Description                       |
+| ------------ | --------- | --------------------------------- |
+| `name`       | `str`     | The name to register the store with. |
+| `file_store` | `FileStore` | The `FileStore` instance to register. |
+
+**Returns:**
+
+The registered `FileStore` instance.
+
+**Example:**
+
+```python
+from tyler import FileStore
+from tyler.utils.registry import register_file_store
+
+# Create a file store with a custom path
+custom_file_store = await FileStore.create(base_path="/mnt/tyler_data/files")
+register_file_store("custom_data", custom_file_store)
+
+# Create a default in-memory file store (though less common for FileStore)
+# For FileStore, usually a path-based store is preferred even for defaults.
+default_fs = await FileStore.create() # Uses default path or in-memory if path not settable
+register_file_store("default_files", default_fs)
+```
+
+### `get_file_store`
+
+Retrieves a registered `FileStore` instance by its name.
+
+```python
+def get_file_store(name: str) -> Optional[FileStore]
+```
+
+**Parameters:**
+
+| Parameter | Type  | Description                                |
+| --------- | ----- | ------------------------------------------ |
+| `name`    | `str` | The name of the `FileStore` to retrieve. |
+
+**Returns:**
+
+The `FileStore` instance if found, otherwise `None`.
+
+**Example:**
+
+```python
+from tyler.utils.registry import get_file_store
+
+custom_fs = get_file_store("custom_data")
+if custom_fs:
+    print(f"Retrieved custom file store: {type(custom_fs)}")
+
+default_fs = get_file_store("default_files")
+if default_fs:
+    print(f"Retrieved default file store: {type(default_fs)}")
+```
+
+## Agent Integration
+
+Once stores are registered, an `Agent` can be configured to use them by name:
+
+```python
+from tyler import Agent, ThreadStore, FileStore
+from tyler.utils.registry import register_thread_store, register_file_store
+
+# Setup and register stores
+db_store = await ThreadStore.create("sqlite+aiosqlite:///main_threads.db")
+fs_store = await FileStore.create(base_path="./tyler_files")
+register_thread_store("main_db", db_store)
+register_file_store("main_files", fs_store)
+
+# Initialize agent
+agent = Agent(
+    name="ConfiguredAgent",
+    purpose="To demonstrate using registered stores.",
+    model_name="gpt-4.1"
+)
+
+# Configure agent to use the registered stores
+agent.set_stores(thread_store_name="main_db", file_store_name="main_files")
+
+# Now, when agent performs operations requiring storage,
+# it will use "main_db" ThreadStore and "main_files" FileStore.
+# For example, agent.go(thread) will save the thread to "main_db".
+```
+
+## Generic Registry Functions (Advanced)
+
+The registry also provides generic functions for registering and retrieving any type of component. These are less commonly used directly for thread/file stores, as the specific helpers above are preferred.
+
+### `register`
+
+```python
+def register(component_type: str, name: str, instance: Any) -> Any
+```
+Registers any component instance with a given type and name.
+
+### `get`
+
+```python
+def get(component_type: str, name: str) -> Optional[Any]
+```
+Retrieves any registered component by its type and name.
+
+### `list_components` (Conceptual, actual name `list` in code)
+The registry has a `list` method (e.g., `Registry.get_instance().list()`) to view registered components, which can be useful for debugging.
+
+```python
+from tyler.utils.registry import list as list_registered_components
+
+all_stores = list_registered_components()
+print("All registered components:", all_stores)
+
+thread_stores_only = list_registered_components(component_type="thread_store")
+print("Thread stores:", thread_stores_only)
+```
+
+## See Also
+- [Core Concepts: Storage](../core-concepts.md#storage)
+- [Configuration Guide](../configuration.md#storage-configuration)
+- [Agent API](./agent.md) (for `set_stores` method)
+- [ThreadStore API](./thread-store.md)
+- [FileStore API](./file-store.md) 

--- a/docs/docs/api-reference/thread-store.md
+++ b/docs/docs/api-reference/thread-store.md
@@ -9,7 +9,7 @@ The `ThreadStore` class provides a unified interface for thread storage with plu
 ## Initialization
 
 ```python
-from tyler.database.thread_store import ThreadStore
+from tyler import ThreadStore
 
 # RECOMMENDED: Factory pattern for immediate connection validation
 # PostgreSQL

--- a/docs/docs/api-reference/thread-store.md
+++ b/docs/docs/api-reference/thread-store.md
@@ -147,23 +147,23 @@ threads = await store.find_by_attributes({
 })
 ```
 
-### find_by_source
+### find_by_platform
 
-Find threads by source name and properties.
+Find threads by platform name and properties.
 
 ```python
-async def find_by_source(
+async def find_by_platform(
     self,
-    source_name: str,
+    platform_name: str,
     properties: Dict[str, Any]
 ) -> List[Thread]
 ```
 
-Returns threads matching source name and properties.
+Returns threads matching platform name and properties.
 
 Example:
 ```python
-threads = await store.find_by_source(
+threads = await store.find_by_platform(
     "slack",
     {
         "channel": "C123",
@@ -329,7 +329,7 @@ print(len(system_messages))  # 0
    await store.save(thread)
    
    # Find related threads
-   related = await store.find_by_source(
+   related = await store.find_by_platform(
        "slack",
        {"channel": "C123"}
    )
@@ -460,7 +460,7 @@ The ThreadStore uses the following tables internally:
    await thread_store.save(thread)
    
    # Later, find the thread by source
-   thread = await thread_store.get_by_source("slack", "1234567890.123")
+   thread = await thread_store.get_by_platform("slack", "1234567890.123")
    ```
 
 5. **Working with Reactions**

--- a/docs/docs/api-reference/thread.md
+++ b/docs/docs/api-reference/thread.md
@@ -61,6 +61,117 @@ message = Message(role="user", content="Hello!")
 thread.add_message(message)
 ```
 
+### get_message_by_id
+
+Return the message with the specified ID.
+
+```python
+def get_message_by_id(
+    self,
+    message_id: str
+) -> Optional[Message]
+```
+
+Returns the message with the specified ID, or None if no message exists with that ID.
+
+#### Example
+
+```python
+message = thread.get_message_by_id("msg_123")
+if message:
+    print(f"Found message: {message.content}")
+```
+
+### add_reaction
+
+Add a reaction to a message in the thread.
+
+```python
+def add_reaction(
+    self,
+    message_id: str,
+    emoji: str,
+    user_id: str
+) -> bool
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `message_id` | str | Yes | None | ID of the message to react to |
+| `emoji` | str | Yes | None | Emoji shortcode (e.g., ":thumbsup:") |
+| `user_id` | str | Yes | None | ID of the user adding the reaction |
+
+#### Returns
+
+`True` if reaction was added, `False` if it wasn't (message not found or already reacted).
+
+#### Example
+
+```python
+thread.add_reaction("msg_123", ":thumbsup:", "user_456")
+```
+
+### remove_reaction
+
+Remove a reaction from a message in the thread.
+
+```python
+def remove_reaction(
+    self,
+    message_id: str,
+    emoji: str,
+    user_id: str
+) -> bool
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `message_id` | str | Yes | None | ID of the message to remove reaction from |
+| `emoji` | str | Yes | None | Emoji shortcode (e.g., ":thumbsup:") |
+| `user_id` | str | Yes | None | ID of the user removing the reaction |
+
+#### Returns
+
+`True` if reaction was removed, `False` if it wasn't (message or reaction not found).
+
+#### Example
+
+```python
+thread.remove_reaction("msg_123", ":thumbsup:", "user_456")
+```
+
+### get_reactions
+
+Get all reactions for a message in the thread.
+
+```python
+def get_reactions(
+    self,
+    message_id: str
+) -> Dict[str, List[str]]
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `message_id` | str | Yes | None | ID of the message to get reactions for |
+
+#### Returns
+
+Dictionary mapping emoji to list of user IDs, or empty dict if message not found.
+
+#### Example
+
+```python
+reactions = thread.get_reactions("msg_123")
+# Example: {":thumbsup:": ["user1", "user2"], ":heart:": ["user1"]}
+```
+
 ### get_messages_for_chat_completion
 
 Return messages in the format expected by chat completion APIs.
@@ -257,6 +368,80 @@ Returns:
 }
 ```
 
+## Message Reactions
+
+The Thread API provides methods for managing reactions to messages. While reactions are associated with specific messages, they are managed at the thread level to maintain consistency and provide centralized access.
+
+### Adding Reactions
+
+To add a reaction to a message:
+
+```python
+# Add a reaction to a message
+thread.add_reaction(message_id, ":heart:", "user123")
+```
+
+The `add_reaction` method takes three parameters:
+- `message_id`: The ID of the message being reacted to
+- `emoji`: The emoji reaction (in standard format, e.g., ":heart:", ":thumbsup:")
+- `user_id`: The ID of the user adding the reaction
+
+### Retrieving Reactions
+
+To get all reactions for a specific message:
+
+```python
+# Get all reactions for a message
+reactions = thread.get_reactions(message_id)
+print(reactions)
+# Output: {":heart:": ["user123", "user456"], ":thumbsup:": ["user789"]}
+```
+
+### Checking for Reactions
+
+To check if a specific user has added a particular reaction:
+
+```python
+# Check if a user has reacted with a specific emoji
+has_reaction = thread.has_reaction(message_id, ":heart:", "user123")
+print(has_reaction)  # Output: True or False
+```
+
+### Removing Reactions
+
+To remove a specific reaction:
+
+```python
+# Remove a reaction
+thread.remove_reaction(message_id, ":heart:", "user123")
+```
+
+### Getting Reaction Counts
+
+To get a count of each reaction type for a message:
+
+```python
+# Get reaction counts
+reactions = thread.get_reactions(message_id)
+reaction_counts = {emoji: len(users) for emoji, users in reactions.items()}
+print(reaction_counts)
+# Output: {":heart:": 2, ":thumbsup:": 1}
+```
+
+### Getting All Users Who Reacted
+
+To get a list of all users who have reacted to a message:
+
+```python
+# Get all users who reacted to a message
+reactions = thread.get_reactions(message_id)
+all_users = set()
+for users in reactions.values():
+    all_users.update(users)
+print(list(all_users))
+# Output: ["user123", "user456", "user789"]
+```
+
 ## Field Validators
 
 ### ensure_timezone
@@ -308,6 +493,9 @@ Converts naive datetime objects to UTC timezone-aware ones.
    
    # Get the system message
    system_msg = thread.get_system_message()
+   
+   # Find a specific message by ID
+   message = thread.get_message_by_id(message_id)
    ```
 
 4. **Source Tracking**
@@ -329,6 +517,20 @@ Converts naive datetime objects to UTC timezone-aware ones.
    # If messages have attachments, provide a file_store
    file_store = FileStore()
    messages = await thread.get_messages_for_chat_completion(file_store=file_store)
+   ```
+
+6. **Managing Reactions**
+   ```python
+   # Add reactions to messages
+   message_ids = [msg.id for msg in thread.messages if msg.role == "assistant"]
+   for message_id in message_ids:
+       thread.add_reaction(message_id, ":thumbsup:", "user1")
+   
+   # Check reaction counts for display
+   for message_id in message_ids:
+       reactions = thread.get_reactions(message_id)
+       thumbs_count = len(reactions.get(":thumbsup:", []))
+       print(f"Message {message_id}: 👍 {thumbs_count}")
    ```
 
 ## See Also

--- a/docs/docs/api-reference/thread.md
+++ b/docs/docs/api-reference/thread.md
@@ -9,7 +9,7 @@ The `Thread` class manages conversations and maintains context between messages.
 ## Initialization
 
 ```python
-from tyler.models.thread import Thread
+from tyler import Thread
 from datetime import datetime, UTC
 
 # Create a new thread

--- a/docs/docs/api-reference/thread.md
+++ b/docs/docs/api-reference/thread.md
@@ -20,7 +20,12 @@ thread = Thread(
     title="My Thread",
     messages=[],
     attributes={},
-    source={"name": "slack", "thread_id": "123"}
+    platforms={
+        "slack": {
+            "channel": "C123",
+            "thread_ts": "1234567890.123"
+        }
+    }
 )
 ```
 
@@ -34,7 +39,7 @@ thread = Thread(
 | `created_at` | datetime | No | now(UTC) | Creation timestamp |
 | `updated_at` | datetime | No | now(UTC) | Last update timestamp |
 | `attributes` | Dict | No | \{\} | Custom metadata |
-| `source` | Optional[Dict[str, Any]] | No | None | Source information (e.g. Slack thread ID) |
+| `platforms` | Dict[str, Dict[str, str]] | No | \{\} | References to where this thread exists on external platforms. Maps platform name to platform-specific identifiers. |
 
 ## Methods
 
@@ -364,7 +369,7 @@ Returns:
     "created_at": str,       # ISO format with timezone if mode="json"
     "updated_at": str,       # ISO format with timezone if mode="json"
     "attributes": Dict,
-    "source": Optional[Dict]
+    "platforms": Optional[Dict]
 }
 ```
 
@@ -501,10 +506,11 @@ Converts naive datetime objects to UTC timezone-aware ones.
 4. **Source Tracking**
    ```python
    thread = Thread(
-       source={
-           "name": "slack",
-           "channel": "C123",
-           "thread_ts": "1234567890.123"
+       platforms={
+           "slack": {
+               "channel": "C123",
+               "thread_ts": "1234567890.123"
+           }
        }
    )
    ```

--- a/docs/docs/api-reference/thread.md
+++ b/docs/docs/api-reference/thread.md
@@ -210,14 +210,14 @@ Returns the most recent message with the specified role, or None if no messages 
 
 ### generate_title
 
-Generate a concise title for the thread using GPT-4o.
+Generate a concise title for the thread using GPT-4.1.
 
 ```python
 @weave.op()
 def generate_title(self) -> str
 ```
 
-Uses GPT-4o to generate a descriptive title based on the conversation content.
+Uses GPT-4.1 to generate a descriptive title based on the conversation content.
 Updates the thread's title and `updated_at` timestamp.
 
 ### get_total_tokens
@@ -475,8 +475,8 @@ Converts naive datetime objects to UTC timezone-aware ones.
    print(f"Average latency: {timing['average_latency']} ms")
    
    # Get model-specific usage
-   model_usage = thread.get_model_usage("gpt-4o")
-   print(f"GPT-4o calls: {model_usage['calls']}")
+   model_usage = thread.get_model_usage("gpt-4.1")
+   print(f"GPT-4.1 calls: {model_usage['calls']}")
    
    # Track tool usage
    tool_usage = thread.get_tool_usage()

--- a/docs/docs/built-in-tools.md
+++ b/docs/docs/built-in-tools.md
@@ -217,7 +217,7 @@ Or when creating an agent programmatically:
 from tyler.models import Agent
 
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with various tasks",
     tools=["web", "slack", "notion", "command_line", "image"]
 )

--- a/docs/docs/chat-with-tyler.md
+++ b/docs/docs/chat-with-tyler.md
@@ -82,7 +82,7 @@ tyler-chat
 With custom configuration:
 
 ```bash
-tyler-chat --model gpt-4o --purpose "Technical support"
+tyler-chat --model gpt-4.1 --purpose "Technical support"
 ```
 
 ### Available commands

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -61,7 +61,7 @@ from tyler import Agent
 
 agent = Agent(
     # Required
-    model_name="gpt-4o",  # LLM model to use
+    model_name="gpt-4.1",  # LLM model to use
     purpose="To help with tasks",  # Agent's purpose
     
     # Optional
@@ -79,7 +79,7 @@ Tyler supports any model available through LiteLLM:
 
 ```python
 # OpenAI
-agent = Agent(model_name="gpt-4o")
+agent = Agent(model_name="gpt-4.1")
 
 # Anthropic
 agent = Agent(model_name="claude-2")
@@ -139,7 +139,7 @@ except Exception as e:
 
 # Create agent with database storage
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with tasks",
     thread_store=store
 )
@@ -220,7 +220,7 @@ file_store = await FileStore.create()
 
 # Pass the file_store instance to an Agent
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with tasks",
     thread_store=thread_store,
     file_store=file_store  # Explicitly pass file_store instance
@@ -294,7 +294,7 @@ weather_tool = {
 from tyler.tools.slack import TOOLS as SLACK_TOOLS
 
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="Slack assistant",
     tools=["slack"]  # This will load all Slack tools
 )
@@ -309,7 +309,7 @@ agent = Agent(
 from tyler.tools.notion import TOOLS as NOTION_TOOLS
 
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="Notion assistant",
     tools=["notion"]  # This will load all Notion tools
 )
@@ -321,7 +321,7 @@ agent = Agent(
 ### Using multiple tools
 ```python
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="Multi-purpose assistant",
     tools=[
         "slack",      # Include all Slack tools

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -226,8 +226,8 @@ agent = Agent(
     file_store=file_store  # Explicitly pass file_store instance
 )
 
-# When saving a thread with attachments, pass the file_store
-await thread_store.save(thread, file_store=file_store)
+# When saving a thread with attachments, the FileStore is used internally
+await thread_store.save(thread)
 ```
 
 The file storage system provides:

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -137,12 +137,17 @@ except Exception as e:
     print(f"Database connection failed: {e}")
     # Handle connection failure appropriately
 
-# Create agent with database storage
+# Register the thread store (and file store if needed)
+from tyler.utils.registry import register_thread_store
+# Assuming 'store' is your created ThreadStore instance as above
+register_thread_store("default_db_store", store)
+
+# Create agent and set it to use the registered store
 agent = Agent(
     model_name="gpt-4.1",
-    purpose="To help with tasks",
-    thread_store=store
+    purpose="To help with tasks"
 )
+agent.set_stores(thread_store_name="default_db_store") # Add file_store_name if using a registered file store
 
 # Must save threads and changes to persist
 thread = Thread()
@@ -218,13 +223,20 @@ file_store = await FileStore.create(
 # Or use default settings from environment variables
 file_store = await FileStore.create()
 
+# Register stores (thread_store would typically be your database store)
+from tyler.utils.registry import register_thread_store, register_file_store
+# Example: using the 'store' from PostgreSQL example and 'file_store' created above
+# register_thread_store("my_thread_store", store) # 'store' is your DB-backed ThreadStore
+register_file_store("my_file_store", file_store)
+
 # Pass the file_store instance to an Agent
 agent = Agent(
     model_name="gpt-4.1",
-    purpose="To help with tasks",
-    thread_store=thread_store,
-    file_store=file_store  # Explicitly pass file_store instance
+    purpose="To help with tasks"
+    # Agent is initialized without direct store instances
 )
+# Set stores by name from the registry
+agent.set_stores(thread_store_name="my_thread_store", file_store_name="my_file_store")
 
 # When saving a thread with attachments, the FileStore is used internally
 await thread_store.save(thread)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -57,7 +57,7 @@ SLACK_SIGNING_SECRET=your-slack-signing-secret
 The `Agent` class accepts various configuration options to customize its behavior:
 
 ```python
-from tyler.models.agent import Agent
+from tyler import Agent
 
 agent = Agent(
     # Required
@@ -104,7 +104,7 @@ Tyler supports multiple database backends for storing threads and messages. The 
 
 #### Memory storage (Default)
 ```python
-from tyler.database.thread_store import ThreadStore
+from tyler import ThreadStore
 
 # Use factory pattern for immediate connection validation
 store = await ThreadStore.create()  # Uses memory backend
@@ -126,7 +126,7 @@ Key characteristics:
 
 #### PostgreSQL storage
 ```python
-from tyler.database.thread_store import ThreadStore
+from tyler import ThreadStore
 
 # Use factory pattern for immediate connection validation
 db_url = "postgresql+asyncpg://user:pass@localhost/dbname"
@@ -164,7 +164,7 @@ Key characteristics:
 
 #### SQLite storage
 ```python
-from tyler.database.thread_store import ThreadStore
+from tyler import ThreadStore
 
 # Use factory pattern for immediate connection validation
 db_url = "sqlite+aiosqlite:///path/to/db.sqlite"
@@ -206,8 +206,7 @@ Configuration options:
 #### Creating and using a FileStore instance
 
 ```python
-from tyler.storage.file_store import FileStore
-from tyler.models.agent import Agent
+from tyler import FileStore, Agent
 
 # Create a FileStore instance with factory pattern
 file_store = await FileStore.create(

--- a/docs/docs/core-concepts.md
+++ b/docs/docs/core-concepts.md
@@ -22,7 +22,7 @@ The `Agent` class is the central component of Tyler. It:
 ### Basic usage
 
 ```python
-from tyler.models.agent import Agent
+from tyler import Agent
 
 agent = Agent(
     model_name="gpt-4o",
@@ -109,7 +109,7 @@ Threads represent conversations and maintain:
 ### Creating threads
 
 ```python
-from tyler.models.thread import Thread
+from tyler import Thread
 
 # Basic thread
 thread = Thread()
@@ -202,7 +202,7 @@ Messages are the basic units of conversation. They contain:
 ### Creating messages
 
 ```python
-from tyler.models.message import Message
+from tyler import Message
 
 # Basic text message
 message = Message(
@@ -320,7 +320,7 @@ Attachments handle files in conversations:
 ### Creating attachments
 
 ```python
-from tyler.models.attachment import Attachment
+from tyler import Attachment
 
 # From binary content
 attachment = Attachment(
@@ -425,7 +425,7 @@ from tyler.tools import (
 ### Using Built-in Tools
 
 ```python
-from tyler.models.agent import Agent
+from tyler import Agent
 
 # Use specific tool modules
 agent = Agent(
@@ -620,7 +620,7 @@ Thread storage handles conversation persistence and retrieval through a unified 
 
 ```python
 # Factory pattern for thread store creation
-from tyler.database.thread_store import ThreadStore
+from tyler import ThreadStore
 
 # In-memory storage
 store = await ThreadStore.create()  # Connects immediately, validates configuration
@@ -704,7 +704,7 @@ threads = await store.find_by_source(
 Tyler provides a unified `FileStore` class for file storage and retrieval. Files are automatically stored and processed when attached to messages.
 
 ```python
-from tyler.storage.file_store import FileStore
+from tyler import FileStore
 
 # Create a file store instance with factory pattern (validates settings immediately)
 file_store = await FileStore.create(
@@ -890,7 +890,7 @@ Tyler supports multiple MCP transport protocols:
 MCP tools can be used with Tyler agents:
 
 ```python
-from tyler.models.agent import Agent
+from tyler import Agent
 
 # Create agent with MCP tools
 agent = Agent(

--- a/docs/docs/core-concepts.md
+++ b/docs/docs/core-concepts.md
@@ -114,13 +114,14 @@ from tyler import Thread
 # Basic thread
 thread = Thread()
 
-# Thread with title and source
+# Thread with title and platforms
 thread = Thread(
     title="Support Conversation",
-    source={
-        "name": "slack",
-        "channel": "C123",
-        "thread_ts": "1234567890.123"
+    platforms={
+        "slack": {
+            "channel": "C123",
+            "thread_ts": "1234567890.123"
+        }
     }
 )
 
@@ -236,8 +237,12 @@ message = Message(
         "priority": "high"
     },
     source={
-        "name": "slack",
-        "thread_id": "123456"
+        "id": "U123456",
+        "name": "John Doe",
+        "type": "user",
+        "attributes": {
+            "email": "john.doe@example.com"
+        }
     }
 )
 
@@ -692,8 +697,8 @@ threads = await store.find_by_attributes({
     "priority": "high"
 })
 
-# Find by source
-threads = await store.find_by_source(
+# Find by platform
+threads = await store.find_by_platform(
     "slack",
     {"channel": "C123", "thread_ts": "123.456"}
 )

--- a/docs/docs/core-concepts.md
+++ b/docs/docs/core-concepts.md
@@ -638,8 +638,16 @@ store = await ThreadStore.create("postgresql+asyncpg://user:pass@localhost/dbnam
 store = await ThreadStore.create("sqlite+aiosqlite:///path/to/db.sqlite")
 # Connects immediately, validates file access
 
-# Use with agent
-agent = Agent(thread_store=store)
+# Register stores
+from tyler.utils.registry import register_thread_store, register_file_store
+thread_store = await ThreadStore.create() # or with DB URL
+file_store = await FileStore.create() # or with path
+register_thread_store("default", thread_store)
+register_file_store("default", file_store)
+
+# Initialize agent and set stores
+agent = Agent(model_name="gpt-4.1", purpose="To help with tasks")
+agent.set_stores(thread_store_name="default", file_store_name="default")
 ```
 
 #### Memory Backend
@@ -721,13 +729,20 @@ file_store = await FileStore.create(
 # Or use default settings from environment variables
 file_store = await FileStore.create()
 
-# Pass file_store to Agent
+# Register stores (if not done already)
+# from tyler.utils.registry import register_thread_store, register_file_store
+# thread_store = await ThreadStore.create() # or with DB URL
+# file_store = await FileStore.create() # or with path
+# register_thread_store("default", thread_store)
+# register_file_store("default", file_store)
+
+# Initialize agent and set stores
 agent = Agent(
     model_name="gpt-4.1",
-    purpose="To help with tasks",
-    thread_store=thread_store,
-    file_store=file_store  # Explicitly pass file_store instance
+    purpose="To help with tasks"
+    # No direct store parameters here
 )
+agent.set_stores(thread_store_name="default", file_store_name="default")
 
 # When handling attachments
 message = Message(role="user", content="Here's a file")

--- a/docs/docs/core-concepts.md
+++ b/docs/docs/core-concepts.md
@@ -10,7 +10,7 @@ This guide explains the core concepts and components that make up Tyler's archit
 
 The `Agent` class is the central component of Tyler. It:
 - Manages conversations through threads
-- Processes messages using LLMs (with GPT-4o as default)
+- Processes messages using LLMs (with GPT-4.1 as default)
 - Executes tools when needed
 - Maintains conversation state
 - Supports streaming responses
@@ -25,7 +25,7 @@ The `Agent` class is the central component of Tyler. It:
 from tyler import Agent
 
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     temperature=0.7,
     purpose="To help with tasks",
     tools=["web", "slack", "notion"]
@@ -265,7 +265,7 @@ Messages automatically track various metrics:
 ```python
 # Message metrics structure
 message.metrics = {
-    "model": "gpt-4o",          # Model used for generation
+    "model": "gpt-4.1",          # Model used for generation
     "timing": {
         "started_at": "2024-02-26T12:00:00Z",
         "ended_at": "2024-02-26T12:00:01Z",
@@ -718,7 +718,7 @@ file_store = await FileStore.create()
 
 # Pass file_store to Agent
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with tasks",
     thread_store=thread_store,
     file_store=file_store  # Explicitly pass file_store instance
@@ -894,7 +894,7 @@ from tyler import Agent
 
 # Create agent with MCP tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     tools=["mcp"],
     config={
         "mcp": {

--- a/docs/docs/examples/database-storage.md
+++ b/docs/docs/examples/database-storage.md
@@ -21,9 +21,7 @@ The example shows:
 from dotenv import load_dotenv
 import os
 import asyncio
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, Thread, Message, ThreadStore
 from tyler.storage import get_file_store
 import weave
 

--- a/docs/docs/examples/database-storage.md
+++ b/docs/docs/examples/database-storage.md
@@ -50,7 +50,7 @@ async def main():
     
     # Create agent with database storage
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help with general questions",
         thread_store=store
     )
@@ -107,7 +107,7 @@ print(f"Initialized file store at: {file_store.base_path}")
 ### 3. Agent Configuration
 ```python
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with general questions",
     thread_store=store
 )
@@ -300,7 +300,7 @@ Database storage offers several advantages over in-memory storage:
 
 Message metrics:
 - Tokens: 128 completion, 84 prompt
-- Model: gpt-4o
+- Model: gpt-4.1
 - Latency: 450ms
 ```
 

--- a/docs/docs/examples/file-storage.md
+++ b/docs/docs/examples/file-storage.md
@@ -56,10 +56,7 @@ await file_store.delete(file_id, storage_path)
 The FileStore integrates seamlessly with the Attachment model:
 
 ```python
-from tyler.models.attachment import Attachment
-from tyler.models.message import Message
-from tyler.models.thread import Thread
-from tyler.database.thread_store import ThreadStore
+from tyler import Attachment, Message, Thread, ThreadStore
 
 # Create an attachment
 attachment = Attachment(

--- a/docs/docs/examples/full-configuration.md
+++ b/docs/docs/examples/full-configuration.md
@@ -19,10 +19,7 @@ The example shows:
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, Thread, Message, ThreadStore
 import asyncio
 import weave
 import os

--- a/docs/docs/examples/full-configuration.md
+++ b/docs/docs/examples/full-configuration.md
@@ -69,7 +69,7 @@ thread_store = ThreadStore()
 # Initialize agent with all available configuration options
 agent = Agent(
     # Core LLM settings
-    model_name="gpt-4o",          # The LLM model to use
+    model_name="gpt-4.1",          # The LLM model to use
     temperature=0.7,              # Controls randomness in responses (0.0 to 1.0)
     
     # Agent identity and behavior
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 ### 1. LLM Settings
 ```python
 agent = Agent(
-    model_name="gpt-4o",     # Model to use
+    model_name="gpt-4.1",     # Model to use
     temperature=0.7,         # Response creativity
 )
 ```

--- a/docs/docs/examples/interrupt-tools.md
+++ b/docs/docs/examples/interrupt-tools.md
@@ -75,7 +75,7 @@ harmful_content_review = {
 async def main():
     # Initialize the agent with web tools and our custom interrupt tool
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help fetch and analyze web content while detecting harmful requests.",
         tools=[
             "web",  # Include the web tools module
@@ -154,7 +154,7 @@ Defines an interrupt tool with:
 ### 2. Agent Configuration
 ```python
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help fetch and analyze web content while detecting harmful requests.",
     tools=[
         "web",

--- a/docs/docs/examples/interrupt-tools.md
+++ b/docs/docs/examples/interrupt-tools.md
@@ -19,9 +19,7 @@ The example shows:
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 import weave
 import asyncio
 import json

--- a/docs/docs/examples/message-attachments.md
+++ b/docs/docs/examples/message-attachments.md
@@ -43,7 +43,7 @@ async def example_basic_attachment():
     
     # Create agent with thread store
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help analyze documents",
         thread_store=thread_store
     )
@@ -88,7 +88,7 @@ async def example_multiple_attachments():
     thread_store = ThreadStore()
     
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         thread_store=thread_store
     )
     
@@ -138,7 +138,7 @@ async def example_attachment_processing():
     thread_store = ThreadStore()
     
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         thread_store=thread_store
     )
 
@@ -153,7 +153,7 @@ async def image_attachment_example():
     
     # Create agent with thread store and vision capability
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To analyze images",
         thread_store=thread_store
     )
@@ -201,7 +201,7 @@ async def audio_attachment_example():
     
     # Create agent with thread store
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To transcribe and analyze audio",
         thread_store=thread_store
     )

--- a/docs/docs/examples/message-attachments.md
+++ b/docs/docs/examples/message-attachments.md
@@ -20,11 +20,7 @@ The example shows:
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.models.attachment import Attachment
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, Thread, Message, Attachment, ThreadStore
 import asyncio
 import os
 import weave

--- a/docs/docs/examples/streaming.md
+++ b/docs/docs/examples/streaming.md
@@ -29,7 +29,7 @@ except Exception as e:
 
 # Initialize the agent
 agent = Agent(
-    model_name="gpt-4o",  # Using latest GPT-4o model
+    model_name="gpt-4.1",  # Using latest GPT-4.1 model
     purpose="To be a helpful assistant that can answer questions and perform tasks.",
     tools=[
         "web",  # Enable web tools for fetching and processing web content
@@ -94,7 +94,7 @@ if __name__ == "__main__":
    - Sets up logging
 
 2. **Agent Configuration**:
-   - Uses the latest GPT-4o model
+   - Uses the latest GPT-4.1 model
    - Enables web and command line tools
    - Sets a specific purpose and temperature
 

--- a/docs/docs/examples/streaming.md
+++ b/docs/docs/examples/streaming.md
@@ -8,9 +8,7 @@ Here's a complete example that shows how to use streaming responses with multipl
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent, StreamUpdate
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler.models.agent import Agent, StreamUpdate, Thread, Message
 import asyncio
 import weave
 import os

--- a/docs/docs/examples/tools-streaming.md
+++ b/docs/docs/examples/tools-streaming.md
@@ -8,9 +8,7 @@ In this example, we'll create a custom translator tool and use it with streaming
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent, StreamUpdate
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler.models.agent import Agent, StreamUpdate, Thread, Message
 import asyncio
 import logging
 

--- a/docs/docs/examples/tools-streaming.md
+++ b/docs/docs/examples/tools-streaming.md
@@ -77,7 +77,7 @@ custom_translator_tool = {
 
 # Initialize the agent
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with translations and web searches",
     tools=[
         "web",                     # Load the web tools module

--- a/docs/docs/examples/using-tools.md
+++ b/docs/docs/examples/using-tools.md
@@ -18,8 +18,7 @@ The example shows:
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
+from tyler import Agent, Thread, Message
 import weave
 import asyncio
 import os

--- a/docs/docs/examples/using-tools.md
+++ b/docs/docs/examples/using-tools.md
@@ -73,7 +73,7 @@ custom_slack_tool = {
 
 # Initialize the agent with both built-in and custom tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with web browsing and posting content to Slack",
     tools=[
         "web",          # Load the web tools module
@@ -134,7 +134,7 @@ Defines a custom tool with:
 ### 2. Agent Initialization
 ```python
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with web browsing and posting content to Slack",
     tools=[
         "web",              # Built-in web tools

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -78,7 +78,7 @@ import asyncio
 
 async def test_installation():
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To test the installation"
     )
     thread = Thread()

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -73,9 +73,7 @@ For a complete list of available configuration options, see the [Configuration G
 You can verify your installation by running a simple test:
 
 ```python
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 import asyncio
 
 async def test_installation():

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -54,9 +54,7 @@ Let's create a simple agent that can use web tools and respond to questions. Thi
 
 ```python
 from dotenv import load_dotenv
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 import asyncio
 import weave
 import os

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -74,7 +74,7 @@ except Exception as e:
 
 # Initialize the agent (uses in-memory storage by default)
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To be a helpful assistant.",
     tools=[
         "web",
@@ -129,7 +129,7 @@ except Exception as e:
 ### 3. Agent initialization
 ```python
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To be a helpful assistant.",
     tools=[
         "web",
@@ -138,7 +138,7 @@ agent = Agent(
 )
 ```
 Creates a new Tyler agent with:
-- GPT-4o model
+- GPT-4.1 model
 - A general-purpose role
 - Web and Slack tools enabled
 - Default in-memory storage
@@ -203,7 +203,7 @@ agent = Agent(
 ### Additional tools
 ```python
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To be a helpful assistant.",
     tools=[
         "web",

--- a/docs/docs/tools/audio.md
+++ b/docs/docs/tools/audio.md
@@ -101,7 +101,7 @@ from tyler.models import Agent, Thread, Message
 
 # Create an agent with audio tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with audio processing",
     tools=["audio"]
 )

--- a/docs/docs/tools/command-line.md
+++ b/docs/docs/tools/command-line.md
@@ -153,7 +153,7 @@ from tyler.models import Agent, Thread, Message
 
 # Create an agent with command line tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with file operations",
     tools=["command_line"]
 )

--- a/docs/docs/tools/files.md
+++ b/docs/docs/tools/files.md
@@ -76,7 +76,7 @@ from tyler.models import Agent, Thread, Message
 
 # Create an agent with file tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with file processing",
     tools=["files"]
 )

--- a/docs/docs/tools/image.md
+++ b/docs/docs/tools/image.md
@@ -91,7 +91,7 @@ from tyler.models import Agent, Thread, Message
 
 # Create an agent with image tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with image generation and analysis",
     tools=["image"]
 )

--- a/docs/docs/tools/mcp.md
+++ b/docs/docs/tools/mcp.md
@@ -55,9 +55,7 @@ import sys
 import weave
 from typing import List, Dict, Any
 
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 from tyler.mcp.utils import initialize_mcp_service, cleanup_mcp_service
 
 async def main():

--- a/docs/docs/tools/mcp.md
+++ b/docs/docs/tools/mcp.md
@@ -100,7 +100,7 @@ async def main():
         # Create an agent with the MCP tools
         agent = Agent(
             name="Tyler",
-            model_name="gpt-4o",
+            model_name="gpt-4.1",
             tools=mcp_tools
         )
         
@@ -174,7 +174,7 @@ try:
     
     # Use the tools with an agent
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         tools=custom_tools
     )
     

--- a/docs/docs/tools/notion.md
+++ b/docs/docs/tools/notion.md
@@ -71,7 +71,7 @@ from tyler.models import Agent, Thread, Message
 
 # Create an agent with Notion tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with Notion content",
     tools=["notion"]
 )

--- a/docs/docs/tools/overview.md
+++ b/docs/docs/tools/overview.md
@@ -213,7 +213,7 @@ custom_calculator = {
 
 # Initialize agent with both built-in and custom tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with various tasks",
     tools=[
         "web",              # Built-in tools

--- a/docs/docs/tools/web.md
+++ b/docs/docs/tools/web.md
@@ -36,7 +36,7 @@ from tyler.models import Agent, Thread, Message
 
 # Create an agent with web tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with web content",
     tools=["web"]
 )

--- a/examples/agent_delegation.py
+++ b/examples/agent_delegation.py
@@ -6,9 +6,7 @@ a main coordinator agent which can delegate tasks to them.
 """
 import asyncio
 import os
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 from tyler.utils.agent_runner import agent_runner
 from tyler.utils.logging import get_logger
 import weave

--- a/examples/agent_delegation.py
+++ b/examples/agent_delegation.py
@@ -28,21 +28,21 @@ async def main():
     # Create specialized agents
     research_agent = Agent(
         name="Research",  # Using simple, unique names
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To conduct in-depth research on topics and provide comprehensive information.",
         tools=["web"]  # Give research agent web search tools
     )
     
     code_agent = Agent(
         name="Code",  # Using simple, unique names
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To write, review, and explain code in various programming languages.",
         tools=[]  # No additional tools needed for coding
     )
     
     creative_agent = Agent(
         name="Creative",  # Using simple, unique names
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To generate creative content such as stories, poems, and marketing copy.",
         tools=[]  # No additional tools needed for creative writing
     )
@@ -50,7 +50,7 @@ async def main():
     # Create main agent with specialized agents as a list
     main_agent = Agent(
         name="Coordinator",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To coordinate work by delegating tasks to specialized agents when appropriate.",
         tools=[],  # No additional tools needed since agents will be added as tools
         agents=[research_agent, code_agent, creative_agent]  # Simple list instead of dictionary

--- a/examples/attachments.py
+++ b/examples/attachments.py
@@ -33,7 +33,7 @@ async def setup():
     
     # Initialize the agent with thread_store, file_store and image tools
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help with image generation and analysis.",
         temperature=0.7,
         tools=["image"],  # Include image tools for this example

--- a/examples/attachments.py
+++ b/examples/attachments.py
@@ -13,12 +13,7 @@ import os
 import asyncio
 import weave
 import sys
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.models.attachment import Attachment
-from tyler.database.thread_store import ThreadStore
-from tyler.storage.file_store import FileStore
+from tyler import Agent, Thread, Message, Attachment, ThreadStore, FileStore
 
 try:
     if os.getenv("WANDB_API_KEY"):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -14,8 +14,7 @@ import os
 import asyncio
 import weave
 import sys
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
+from tyler import Agent, Thread, Message
 
 try:
     if os.getenv("WANDB_API_KEY"):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -25,7 +25,7 @@ except Exception as e:
 
 # Initialize the agent
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To be a helpful assistant.",
     temperature=0.7
 )

--- a/examples/explicit_stores.py
+++ b/examples/explicit_stores.py
@@ -1,0 +1,73 @@
+import asyncio
+from tyler import Agent, Thread, Message, ThreadStore, FileStore
+# Import the individual store classes and registration functions
+from tyler.utils.registry import register_thread_store, register_file_store
+
+async def main():
+    """
+    Demonstrates explicitly creating and setting default in-memory stores for an Agent.
+    """
+    # 1. Create default in-memory stores individually.
+    #    Calling .create() without arguments defaults to in-memory.
+    thread_store = await ThreadStore.create()
+    file_store = await FileStore.create()
+    print(f"Created in-memory stores:")
+    print(f"  Thread Store: {type(thread_store)}")
+    print(f"  File Store: {type(file_store)}")
+    
+    # 2. Register the stores in the global registry under the name "default".
+    register_thread_store("default", thread_store)
+    register_file_store("default", file_store)
+    print(f"Registered stores with name 'default'")
+
+    # 3. Initialize the agent.
+    #    It doesn't know about the stores yet.
+    agent = Agent(
+        name="StoreAwareAssistant",
+        purpose="Answer questions concisely using explicitly set stores.",
+        model_name="gpt-4o" # Using preferred model
+    )
+    print(f"Initialized agent: {agent.name}")
+
+    # 4. Explicitly configure the agent to use the stores named 'default'
+    #    from the registry. The agent will now look these up when needed.
+    agent.set_stores(thread_store_name="default", file_store_name="default")
+    print("Agent configured to use 'default' stores from registry.")
+
+    # 5. Create a new thread. Because the agent is configured,
+    #    operations like saving the thread will use the registered 'default' ThreadStore.
+    thread = Thread()
+    print(f"Created new thread with ID: {thread.id}")
+
+    # 6. Add a user message
+    user_message = Message(role="user", content="What is the capital of Spain?")
+    thread.add_message(user_message)
+    print(f"Added user message: '{user_message.content}'")
+
+    # 7. Run the agent. It will use the configured stores internally.
+    print("Running agent...")
+    final_thread, new_messages = await agent.go(thread)
+    print("Agent finished processing.")
+
+    # 8. Print the assistant's response
+    if new_messages:
+        # Filter for the actual assistant response (last non-tool message)
+        assistant_message = next((msg for msg in reversed(new_messages) if msg.role == 'assistant'), None)
+        if assistant_message:
+            print(f"Assistant Response: {assistant_message.content}")
+        else:
+            print("No assistant message found in new messages.")
+            print("All new messages:", new_messages)
+    else:
+        print("No new messages were generated.")
+
+    # Note: Since the stores are in-memory, the thread data still only exists
+    # for the duration of this script run. To persist data, you would provide
+    # a database URL to ThreadStore.create and a directory path to FileStore.create
+
+if __name__ == "__main__":
+    # Added basic error handling for asyncio run
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        print(f"An error occurred: {e}") 

--- a/examples/explicit_stores.py
+++ b/examples/explicit_stores.py
@@ -25,7 +25,7 @@ async def main():
     agent = Agent(
         name="StoreAwareAssistant",
         purpose="Answer questions concisely using explicitly set stores.",
-        model_name="gpt-4o" # Using preferred model
+        model_name="gpt-4.1" # Using preferred model
     )
     print(f"Initialized agent: {agent.name}")
 

--- a/examples/mcp_basic.py
+++ b/examples/mcp_basic.py
@@ -16,9 +16,7 @@ import sys
 import weave
 from typing import List, Dict, Any
 
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 from tyler.mcp.utils import initialize_mcp_service, cleanup_mcp_service
 
 # Add the parent directory to the path so we can import the example utils

--- a/examples/mcp_basic.py
+++ b/examples/mcp_basic.py
@@ -72,7 +72,7 @@ async def main():
         # Create an agent with the MCP tools
         agent = Agent(
             name="Tyler",
-            model_name="gpt-4o",
+            model_name="gpt-4.1",
             tools=mcp_tools
         )
         

--- a/examples/reactions_example.py
+++ b/examples/reactions_example.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating how to use message reactions in Tyler.
+
+This example shows how to:
+1. Add reactions to messages
+2. Remove reactions from messages
+3. Get reactions for a message
+4. Save/load threads with reactions to/from the database
+"""
+
+import asyncio
+from typing import Dict, List
+from tyler.models.thread import Thread
+from tyler.models.message import Message
+from tyler.database.thread_store import ThreadStore
+
+
+async def main():
+    # Create an in-memory ThreadStore for this example
+    thread_store = await ThreadStore.create()
+    
+    # Create a new thread with some messages
+    thread = Thread(title="Reactions Example")
+    
+    # Add some messages to the thread
+    user_msg = Message(role="user", content="Hello! I have a question about reactions.")
+    thread.add_message(user_msg)
+    
+    assistant_msg = Message(role="assistant", content="Sure, I'd be happy to help with reactions!")
+    thread.add_message(assistant_msg)
+    
+    user_msg2 = Message(role="user", content="How do I add a thumbs up?")
+    thread.add_message(user_msg2)
+    
+    assistant_msg2 = Message(role="assistant", content="It's easy! Just click the emoji button.")
+    thread.add_message(assistant_msg2)
+    
+    # Print the thread messages
+    print(f"Thread '{thread.title}' has {len(thread.messages)} messages:")
+    for msg in thread.messages:
+        print(f"  - {msg.role}: {msg.content}")
+    print()
+    
+    # Add reactions to messages
+    print("Adding reactions...")
+    
+    # User 1 adds thumbs up to assistant's first message
+    thread.add_reaction(assistant_msg.id, ":thumbsup:", "user1")
+    
+    # User 2 also adds thumbs up to the same message
+    thread.add_reaction(assistant_msg.id, ":thumbsup:", "user2")
+    
+    # User 1 adds heart to assistant's second message
+    thread.add_reaction(assistant_msg2.id, ":heart:", "user1")
+    
+    # User 3 adds rocket to assistant's second message
+    thread.add_reaction(assistant_msg2.id, ":rocket:", "user3")
+    
+    # Display reactions
+    print("\nReactions after adding:")
+    for msg in thread.messages:
+        if msg.reactions:
+            print(f"Message '{msg.content}' has reactions:")
+            for emoji, users in msg.reactions.items():
+                print(f"  - {emoji}: {', '.join(users)}")
+    
+    # Remove a reaction
+    print("\nRemoving User 1's heart reaction from second message...")
+    thread.remove_reaction(assistant_msg2.id, ":heart:", "user1")
+    
+    # Display reactions after removal
+    print("\nReactions after removal:")
+    for msg in thread.messages:
+        if msg.reactions:
+            print(f"Message '{msg.content}' has reactions:")
+            for emoji, users in msg.reactions.items():
+                print(f"  - {emoji}: {', '.join(users)}")
+    
+    # Save thread to database
+    print("\nSaving thread to database...")
+    await thread_store.save(thread)
+    
+    # Retrieve thread from database
+    print("Retrieving thread from database...")
+    retrieved_thread = await thread_store.get(thread.id)
+    
+    # Display reactions from retrieved thread
+    print("\nReactions in retrieved thread:")
+    for msg in retrieved_thread.messages:
+        if msg.reactions:
+            print(f"Message '{msg.content}' has reactions:")
+            for emoji, users in msg.reactions.items():
+                print(f"  - {emoji}: {', '.join(users)}")
+    
+    print("\nExample completed successfully!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/examples/reactions_example.py
+++ b/examples/reactions_example.py
@@ -11,10 +11,7 @@ This example shows how to:
 
 import asyncio
 from typing import Dict, List
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.database.thread_store import ThreadStore
-
+from tyler import Thread, Message, ThreadStore
 
 async def main():
     # Create an in-memory ThreadStore for this example

--- a/examples/selective_tools.py
+++ b/examples/selective_tools.py
@@ -14,8 +14,7 @@ import os
 import asyncio
 import weave
 import sys
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
+from tyler import Agent, Thread, Message
 
 # Initialize weave for tracing if configured
 try:

--- a/examples/selective_tools.py
+++ b/examples/selective_tools.py
@@ -27,7 +27,7 @@ except Exception as e:
 # Initialize an agent with selective tools from the notion module
 # This agent can only search Notion but can't create/edit pages
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with searching Notion without being able to modify anything",
     tools=[
         "notion:notion-search,notion-get_page",  # Only include search and get_page tools

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -14,8 +14,7 @@ import os
 import asyncio
 import weave
 import sys
-from tyler.models.agent import Agent, StreamUpdate
-from tyler.models.thread import Thread, Message
+from tyler import Agent, Thread, Message, StreamUpdate
 
 try:
     if os.getenv("WANDB_API_KEY"):

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -25,7 +25,7 @@ except Exception as e:
 
 # Initialize the agent
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To demonstrate streaming updates.",
     temperature=0.7
 )

--- a/examples/tools_audio.py
+++ b/examples/tools_audio.py
@@ -33,7 +33,7 @@ thread_store = ThreadStore()
 async def init():
     # Initialize the agent with audio tools and thread store
     return Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help convert text to speech and transcribe speech to text.",
         tools=["audio"],  # Load the audio tools module
         temperature=0.7,

--- a/examples/tools_audio.py
+++ b/examples/tools_audio.py
@@ -18,9 +18,7 @@ import sys
 import json
 import base64
 from pathlib import Path
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, Thread, Message, ThreadStore
 
 try:
     if os.getenv("WANDB_API_KEY"):

--- a/examples/tools_basic.py
+++ b/examples/tools_basic.py
@@ -14,8 +14,7 @@ import os
 import asyncio
 import weave
 import sys
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
+from tyler import Agent, Thread, Message
 
 def custom_calculator_implementation(operation: str, x: float, y: float) -> str:
     """

--- a/examples/tools_basic.py
+++ b/examples/tools_basic.py
@@ -78,7 +78,7 @@ except Exception as e:
 
 # Initialize the agent with both built-in and custom tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with calculations and web searches",
     tools=[
         "web",                    # Load the web tools module

--- a/examples/tools_files.py
+++ b/examples/tools_files.py
@@ -21,11 +21,7 @@ import weave
 import sys
 import json
 from pathlib import Path
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.models.attachment import Attachment
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, Thread, Message, Attachment, ThreadStore
 
 try:
     if os.getenv("WANDB_API_KEY"):

--- a/examples/tools_files.py
+++ b/examples/tools_files.py
@@ -36,7 +36,7 @@ thread_store = ThreadStore()
 async def init():
     # Initialize the agent with files tools and thread store
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help extract and analyze content from PDF files.",
         tools=["files"],  # Use the files module
         temperature=0.7,

--- a/examples/tools_image.py
+++ b/examples/tools_image.py
@@ -31,7 +31,7 @@ thread_store = ThreadStore()
 async def init():
     # Initialize the agent with image tools and thread store
     return Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="To help create and generate images based on text descriptions.",
         tools=["image"],  # Load the image tools module
         temperature=0.7,

--- a/examples/tools_image.py
+++ b/examples/tools_image.py
@@ -16,10 +16,7 @@ import asyncio
 import weave
 import sys
 import json
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread, Message
-from tyler.models.attachment import Attachment
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, Thread, Message, Attachment, ThreadStore
 
 try:
     if os.getenv("WANDB_API_KEY"):

--- a/examples/tools_streaming.py
+++ b/examples/tools_streaming.py
@@ -78,7 +78,7 @@ except Exception as e:
 
 # Initialize the agent with both built-in and custom tools
 agent = Agent(
-    model_name="gpt-4o",
+    model_name="gpt-4.1",
     purpose="To help with calculations and web searches",
     tools=[
         "web",                    # Load the web tools module

--- a/examples/tools_streaming.py
+++ b/examples/tools_streaming.py
@@ -14,8 +14,7 @@ import os
 import asyncio
 import weave
 import sys
-from tyler.models.agent import Agent, StreamUpdate
-from tyler.models.thread import Thread, Message
+from tyler import Agent, Thread, Message, StreamUpdate
 
 def custom_calculator_implementation(operation: str, x: float, y: float) -> str:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ Repository = "https://github.com/adamwdraper/tyler"
 "Bug Tracker" = "https://github.com/adamwdraper/tyler/issues"
 
 [project.scripts]
+tyler = "tyler.cli.main:main"
 tyler-db = "tyler.database.cli:main"
 tyler-chat = "tyler.cli.chat:main"
 

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -6,10 +6,7 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, text, inspect
 from sqlalchemy.ext.asyncio import create_async_engine
-from tyler.database.thread_store import ThreadStore
-from tyler.database.models import ThreadRecord
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import ThreadStore, Thread, Message
 
 pytest_plugins = ('pytest_asyncio',)
 

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -77,7 +77,7 @@ async def test_initial_migration(temp_db, alembic_config):
         assert 'id' in columns
         assert 'title' in columns
         assert 'attributes' in columns
-        assert 'source' in columns
+        assert 'platforms' in columns
         assert 'metrics' in columns
         assert 'created_at' in columns
         assert 'updated_at' in columns
@@ -106,7 +106,12 @@ async def test_migration_with_data(temp_db, alembic_config):
     thread = Thread()
     thread.title = "Test Thread"
     thread.attributes = {"category": "test", "priority": "high"}
-    thread.source = {"name": "test", "id": "123"}
+    thread.platforms = {
+        "slack": {
+            "channel": "C123",
+            "thread_ts": "1234567890.123"
+        }
+    }
     
     # Add messages
     thread.add_message(Message(role="user", content="Test message"))
@@ -144,7 +149,7 @@ async def test_migration_with_data(temp_db, alembic_config):
             # Restore threads first
             for row in thread_data:
                 conn.execute(
-                    text("INSERT INTO threads (id, title, attributes, source, metrics, created_at, updated_at) VALUES (:id, :title, :attributes, :source, :metrics, :created_at, :updated_at)"),
+                    text("INSERT INTO threads (id, title, attributes, platforms, metrics, created_at, updated_at) VALUES (:id, :title, :attributes, :platforms, :metrics, :created_at, :updated_at)"),
                     row
                 )
             
@@ -162,7 +167,7 @@ async def test_migration_with_data(temp_db, alembic_config):
     assert loaded_thread is not None
     assert loaded_thread.title == thread.title
     assert loaded_thread.attributes == thread.attributes
-    assert loaded_thread.source == thread.source
+    assert loaded_thread.platforms == thread.platforms
     assert len(loaded_thread.messages) == len(thread.messages)
     
     # Verify message content

--- a/tests/database/test_storage_backend.py
+++ b/tests/database/test_storage_backend.py
@@ -61,15 +61,15 @@ async def test_memory_backend_find(sample_thread):
     assert len(found) == 1
     assert found[0].id == thread1.id
 
-    # Test find by source
-    thread1.source = {'name': 'slack', 'channel': 'general'}
-    thread2.source = {'name': 'notion'}
+    # Test find by platform
+    thread1.platforms = {'slack': {'channel': 'general'}}
+    thread2.platforms = {'notion': {}}
     await backend.save(thread1)
     await backend.save(thread2)
 
-    found_source = await backend.find_by_source('slack', {'channel': 'general'})
-    assert len(found_source) == 1
-    assert found_source[0].id == thread1.id
+    found_platform = await backend.find_by_platform('slack', {'channel': 'general'})
+    assert len(found_platform) == 1
+    assert found_platform[0].id == thread1.id
 
 
 @pytest.mark.asyncio
@@ -130,15 +130,15 @@ async def test_sql_backend_find(tmp_path):
     assert len(found) == 1
     assert found[0].id == 'sql-thread-1'
 
-    # Test find by source
-    thread1.source = {'name': 'github', 'repo': 'tyler'}
-    thread2.source = {'name': 'gitlab'}
+    # Test find by platform
+    thread1.platforms = {'github': {'repo': 'tyler'}}
+    thread2.platforms = {'gitlab': {}}
     await backend.save(thread1)
     await backend.save(thread2)
 
-    found_source = await backend.find_by_source('github', {'repo': 'tyler'})
-    assert len(found_source) == 1
-    assert found_source[0].id == 'sql-thread-1'
+    found_platform = await backend.find_by_platform('github', {'repo': 'tyler'})
+    assert len(found_platform) == 1
+    assert found_platform[0].id == 'sql-thread-1'
 
 
 @pytest.mark.asyncio

--- a/tests/database/test_storage_backend.py
+++ b/tests/database/test_storage_backend.py
@@ -4,8 +4,7 @@ import pytest
 from datetime import datetime, UTC
 
 from tyler.database.storage_backend import MemoryBackend, SQLBackend
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Thread, Message
 from tyler.database.models import Base
 
 

--- a/tests/database/test_thread_store.py
+++ b/tests/database/test_thread_store.py
@@ -5,13 +5,9 @@ import tempfile
 from datetime import datetime, UTC
 from sqlalchemy import select, text
 from sqlalchemy.orm import selectinload
-from tyler.database.thread_store import ThreadStore
-from tyler.database.models import ThreadRecord
+from tyler import Thread, Message, Attachment, ThreadStore
 from tyler.database.storage_backend import MemoryBackend, SQLBackend
-from tyler.models.thread import Thread
-from tyler.models.message import Message
 from tyler.database.models import Base
-from tyler.models.attachment import Attachment
 
 pytest_plugins = ('pytest_asyncio',)
 

--- a/tests/database/test_thread_store.py
+++ b/tests/database/test_thread_store.py
@@ -223,19 +223,19 @@ async def test_find_by_attributes(thread_store):
     assert results[0].id == "thread-1"
 
 @pytest.mark.asyncio
-async def test_find_by_source(thread_store):
-    """Test finding threads by source"""
-    # Create threads with different sources
+async def test_find_by_platform(thread_store):
+    """Test finding threads by platform"""
+    # Create threads with different platforms
     thread1 = Thread(id="thread-1", title="Thread 1")
-    thread1.source = {"name": "slack", "channel": "general"}
+    thread1.platforms = {"slack": {"channel": "general"}}
     await thread_store.save(thread1)
     
     thread2 = Thread(id="thread-2", title="Thread 2")
-    thread2.source = {"name": "notion", "page_id": "123"}
+    thread2.platforms = {"notion": {"page_id": "123"}}
     await thread_store.save(thread2)
     
-    # Search by source using the ThreadStore API
-    results = await thread_store.find_by_source("slack", {})
+    # Search by platform using the ThreadStore API
+    results = await thread_store.find_by_platform("slack", {})
     
     assert len(results) == 1
     assert results[0].id == "thread-1"

--- a/tests/database/test_thread_store.py
+++ b/tests/database/test_thread_store.py
@@ -559,7 +559,7 @@ async def test_save_thread_partial_attachment_failure(thread_store):
     assert retrieved_thread is None
     
     # Verify the file was cleaned up from storage
-    from tyler.storage.file_store import FileStore
+    from tyler import FileStore
     store = FileStore()
     files = await store.list_files()
     assert not any(f.endswith("good.txt") for f in files)
@@ -626,7 +626,7 @@ async def test_save_thread_database_failure_keeps_attachments(thread_store, monk
         assert "Database error" in str(exc_info.value)
     
     # Verify attachment files still exist (weren't cleaned up)
-    from tyler.storage.file_store import FileStore
+    from tyler import FileStore
     store = FileStore()
     files = await store.list_files()
     assert any(attachment.file_id in f for f in files), f"Expected to find file ID {attachment.file_id} in {files}"

--- a/tests/integration/test_agent_delegation_integration.py
+++ b/tests/integration/test_agent_delegation_integration.py
@@ -11,12 +11,9 @@ from unittest.mock import patch, MagicMock, AsyncMock
 import json
 import types
 import asyncio
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message, ThreadStore
 from tyler.utils.agent_runner import agent_runner
 from tyler.utils.tool_runner import tool_runner
-from tyler.database.thread_store import ThreadStore
 from datetime import datetime, UTC
 
 # Reset agent_runner between tests

--- a/tests/integration/test_agent_delegation_integration.py
+++ b/tests/integration/test_agent_delegation_integration.py
@@ -66,7 +66,7 @@ def create_tool_call_response(tool_calls):
     # Add choice to response
     response.choices = [choice]
     response.id = "test-id"
-    response.model = "gpt-4o"
+    response.model = "gpt-4.1"
     
     # Add usage
     response.usage = types.SimpleNamespace()
@@ -95,7 +95,7 @@ def create_assistant_response(content):
     # Add choice to response
     response.choices = [choice]
     response.id = "test-id"
-    response.model = "gpt-4o"
+    response.model = "gpt-4.1"
     
     # Add usage
     response.usage = types.SimpleNamespace()
@@ -111,21 +111,21 @@ async def test_parallel_agent_delegation(mock_thread_store):
     # Create specialized agents
     research_agent = Agent(
         name="Research",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Research purpose",
         thread_store=mock_thread_store
     )
     
     code_agent = Agent(
         name="Code",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Code purpose",
         thread_store=mock_thread_store
     )
     
     creative_agent = Agent(
         name="Creative",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Creative purpose",
         thread_store=mock_thread_store
     )
@@ -133,7 +133,7 @@ async def test_parallel_agent_delegation(mock_thread_store):
     # Create coordinator agent
     coordinator_agent = Agent(
         name="Coordinator",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Coordination purpose",
         agents=[research_agent, code_agent, creative_agent],
         thread_store=mock_thread_store
@@ -249,14 +249,14 @@ async def test_agent_delegation_error_handling(mock_thread_store):
     # Create agents
     failing_agent = Agent(
         name="FailingAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Agent that will fail",
         thread_store=mock_thread_store
     )
     
     working_agent = Agent(
         name="WorkingAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Agent that works correctly",
         thread_store=mock_thread_store
     )
@@ -264,7 +264,7 @@ async def test_agent_delegation_error_handling(mock_thread_store):
     # Create coordinator agent
     coordinator_agent = Agent(
         name="ErrorHandlingCoordinator",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Coordinator that handles errors",
         agents=[failing_agent, working_agent],
         thread_store=mock_thread_store

--- a/tests/models/test_agent.py
+++ b/tests/models/test_agent.py
@@ -51,7 +51,7 @@ def mock_tool_runner():
 
 @pytest.fixture
 def mock_thread_store():
-    """Create a mock thread store for testing."""
+    """Create a mock thread store for testing and register it in the registry."""
     class MockThreadStore(ThreadStore):
         def __init__(self):
             super().__init__()  # Initialize with memory backend
@@ -76,7 +76,23 @@ def mock_thread_store():
     store.list.return_value = []
     store.find_by_attributes.return_value = []
     store.find_by_source.return_value = []
+    
+    # Patch the registry.get function
+    with patch('tyler.utils.registry.get') as mock_get:
+        mock_get.return_value = store
+    
     return store
+
+@pytest.fixture
+def mock_file_store():
+    """Create a mock file store for testing and register it in the registry."""
+    file_store = MagicMock()
+    
+    # Register the store in the registry
+    with patch('tyler.utils.registry.get') as mock_get:
+        mock_get.side_effect = lambda component_type, name: file_store if component_type == "file_store" else None
+    
+    return file_store
 
 @pytest.fixture
 def mock_wandb():
@@ -103,19 +119,34 @@ def thread():
     )
 
 @pytest.fixture
-def agent(mock_tool_runner, mock_thread_store, mock_openai, mock_wandb, mock_litellm, mock_prompt, mock_file_processor, mock_env_vars):
-    """Create a test agent"""
-    agent = Agent(
-        name="Tyler",
-        model_name="gpt-4",
-        temperature=0.5,
-        purpose="test purpose",
-        notes="test notes",
-        thread_store=mock_thread_store,
-        litellm=mock_litellm,
-        prompt=mock_prompt
-    )
-    return agent
+def agent(mock_tool_runner, mock_thread_store, mock_file_store, mock_openai, mock_wandb, mock_litellm, mock_prompt, mock_file_processor, mock_env_vars):
+    """Create a test agent that uses the registry for stores"""
+    with patch('tyler.utils.registry.get') as mock_get:
+        mock_get.side_effect = lambda component_type, name: mock_thread_store if component_type == "thread_store" else mock_file_store if component_type == "file_store" else None
+        
+        agent = Agent(
+            name="Tyler",
+            model_name="gpt-4",
+            temperature=0.5,
+            purpose="test purpose",
+            notes="test notes"
+        )
+        
+        # Create proper async method mocks that return our test stores
+        async def mock_get_thread_store():
+            return mock_thread_store
+        
+        async def mock_get_file_store():
+            return mock_file_store
+            
+        # Replace the async methods with our properly mocked async versions
+        agent._get_thread_store = mock_get_thread_store
+        agent._get_file_store = mock_get_file_store
+        
+        # Set up the agent to use the registry
+        agent.set_stores(thread_store_name="default", file_store_name="default")
+        
+        return agent
 
 def test_init(agent):
     """Test Agent initialization"""
@@ -157,12 +188,14 @@ async def test_go_max_recursion(agent, mock_thread_store):
         
         mock_step.side_effect = side_effect
         
-        result_thread, new_messages = await agent.go("test-conv")
-        
-        assert len(new_messages) == 1
-        assert new_messages[0].role == "assistant"
-        assert new_messages[0].content == "Maximum tool iteration count reached. Stopping further tool calls."
-        mock_thread_store.save.assert_called_once_with(result_thread)
+        # No need to patch _get_thread_store since we already set it in the fixture
+        with patch.object(agent, '_get_thread', return_value=thread):
+            result_thread, new_messages = await agent.go("test-conv")
+            
+            assert len(new_messages) == 1
+            assert new_messages[0].role == "assistant"
+            assert new_messages[0].content == "Maximum tool iteration count reached. Stopping further tool calls."
+            mock_thread_store.save.assert_called_with(result_thread)
 
 @pytest.mark.asyncio
 async def test_go_no_tool_calls(agent, mock_thread_store, mock_prompt, mock_litellm):
@@ -197,19 +230,21 @@ async def test_go_no_tool_calls(agent, mock_thread_store, mock_prompt, mock_lite
 
     agent._get_completion = DummyCompletion()
 
-    result_thread, new_messages = await agent.go("test-conv")
+    # No need to patch _get_thread_store since we already set it in the fixture
+    with patch.object(agent, '_get_thread', return_value=thread):
+        result_thread, new_messages = await agent.go("test-conv")
 
-    # Since system messages are ephemeral, we only expect the assistant message
-    assert len(result_thread.messages) == 1  
-    assert result_thread.messages[0].role == "assistant"
-    assert result_thread.messages[0].content == "Test response"
-    assert len(new_messages) == 1
-    assert new_messages[0].role == "assistant"
-    assert "metrics" in new_messages[0].model_dump()
-    assert "timing" in new_messages[0].metrics
-    assert "usage" in new_messages[0].metrics
-    mock_thread_store.save.assert_called_with(result_thread)
-    assert agent._iteration_count == 0
+        # Since system messages are ephemeral, we only expect the assistant message
+        assert len(result_thread.messages) == 1  
+        assert result_thread.messages[0].role == "assistant"
+        assert result_thread.messages[0].content == "Test response"
+        assert len(new_messages) == 1
+        assert new_messages[0].role == "assistant"
+        assert "metrics" in new_messages[0].model_dump()
+        assert "timing" in new_messages[0].metrics
+        assert "usage" in new_messages[0].metrics
+        mock_thread_store.save.assert_called_with(result_thread)
+        assert agent._iteration_count == 0
 
 @pytest.mark.asyncio
 async def test_go_with_tool_calls(agent, mock_thread_store, mock_prompt, mock_litellm):
@@ -282,7 +317,9 @@ async def test_go_with_tool_calls(agent, mock_thread_store, mock_prompt, mock_li
             })
             patched_tool_runner.get_tool_attributes.return_value = None
 
-            result_thread, new_messages = await agent.go("test-conv")
+            # No need to patch _get_thread_store since we already set it in the fixture
+            with patch.object(agent, '_get_thread', return_value=thread):
+                result_thread, new_messages = await agent.go("test-conv")
 
     # Verify the sequence of messages (without system message)
     messages = result_thread.messages
@@ -459,6 +496,7 @@ async def test_handle_max_iterations(agent, mock_thread_store):
     thread = Thread(id="test-thread")
     new_messages = [Message(role="user", content="test")]
     
+    # The _handle_max_iterations method uses _get_thread_store which is already patched in the fixture
     result_thread, filtered_messages = await agent._handle_max_iterations(thread, new_messages)
     
     assert len(filtered_messages) == 1
@@ -476,7 +514,13 @@ async def test_get_thread_direct(agent):
 @pytest.mark.asyncio
 async def test_get_thread_missing_store(agent):
     """Test getting thread by ID without thread store"""
-    agent.thread_store = None
+    # Create async method that returns None
+    async def mock_get_none():
+        return None
+        
+    # Replace with our mock
+    agent._get_thread_store = mock_get_none
+    
     with pytest.raises(ValueError, match="Thread store is required when passing thread ID"):
         await agent._get_thread("test-thread-id")
 
@@ -610,20 +654,22 @@ async def test_go_with_weave_metrics(agent, mock_thread_store, mock_prompt):
     
     # Patch the method that actually generates the metrics
     with patch.object(agent, 'step', side_effect=mock_step_metrics):
-        result_thread, new_messages = await agent.go(thread)
-        
-        assert len(new_messages) == 1
-        message = new_messages[0]
-        assert 'model' in message.metrics
-        assert 'timing' in message.metrics
-        assert 'usage' in message.metrics
-        assert message.metrics['usage'] == {
-            'completion_tokens': 10,
-            'prompt_tokens': 20,
-            'total_tokens': 30
-        }
-        assert message.metrics['weave_call']['id'] == "weave-call-id"
-        assert message.metrics['weave_call']['ui_url'] == "https://weave.ui/call-id"
+        # No need to patch _get_thread_store since we already set it in the fixture
+        with patch.object(agent, '_get_thread', return_value=thread):
+            result_thread, new_messages = await agent.go(thread)
+            
+            assert len(new_messages) == 1
+            message = new_messages[0]
+            assert 'model' in message.metrics
+            assert 'timing' in message.metrics
+            assert 'usage' in message.metrics
+            assert message.metrics['usage'] == {
+                'completion_tokens': 10,
+                'prompt_tokens': 20,
+                'total_tokens': 30
+            }
+            assert message.metrics['weave_call']['id'] == "weave-call-id"
+            assert message.metrics['weave_call']['ui_url'] == "https://weave.ui/call-id"
 
 @pytest.mark.asyncio
 async def test_get_thread_no_store():
@@ -635,11 +681,11 @@ async def test_get_thread_no_store():
     result = await agent._get_thread(thread)
     assert result == thread
     
-    # Should fail with thread ID
-    agent.thread_store = None  # Ensure thread store is None
-    with pytest.raises(ValueError) as exc_info:
-        await agent._get_thread("test-thread-id")
-    assert str(exc_info.value) == "Thread store is required when passing thread ID"
+    # Should fail with thread ID when store is None
+    with patch.object(agent, '_get_thread_store', return_value=None):
+        with pytest.raises(ValueError) as exc_info:
+            await agent._get_thread("test-thread-id")
+        assert str(exc_info.value) == "Thread store is required when passing thread ID"
 
 @pytest.mark.asyncio
 async def test_go_with_multiple_tool_call_iterations(agent, mock_thread_store, mock_prompt, mock_litellm):
@@ -780,7 +826,9 @@ async def test_go_with_multiple_tool_call_iterations(agent, mock_thread_store, m
         ])
         patched_tool_runner.get_tool_attributes.return_value = None
 
-        result_thread, new_messages = await agent.go("test-conv")
+        # No need to patch _get_thread_store since we already set it in the fixture
+        with patch.object(agent, '_get_thread', return_value=thread):
+            result_thread, new_messages = await agent.go("test-conv")
 
     # Verify the sequence of messages (without system message)
     messages = result_thread.messages
@@ -894,7 +942,9 @@ async def test_go_with_tool_calls_no_content(agent, mock_thread_store, mock_prom
         })
         patched_tool_runner.get_tool_attributes.return_value = None
 
-        result_thread, new_messages = await agent.go("test-conv")
+        # No need to patch _get_thread_store since we already set it in the fixture
+        with patch.object(agent, '_get_thread', return_value=thread):
+            result_thread, new_messages = await agent.go("test-conv")
 
     # Verify the sequence of messages (without system message)
     messages = result_thread.messages
@@ -1022,16 +1072,20 @@ async def test_process_tool_call_with_image_attachment():
 @pytest.mark.asyncio
 async def test_go_with_tool_returning_image():
     """Test the go() method when a tool returns an image attachment."""
-    # Create thread store (will initialize automatically when needed)
-    mock_thread_store = ThreadStore()
-
-    # Create and save thread
-    thread = Thread(id="test-thread")
-    await mock_thread_store.save(thread)  # This will automatically initialize the thread store
-
-    # Create agent with mock thread store
-    agent = Agent(thread_store=mock_thread_store)
-
+    # Create thread store with async methods
+    mock_thread_store = MagicMock()
+    mock_thread_store.save = AsyncMock(return_value=None)
+    mock_thread_store.get = AsyncMock(return_value=Thread(id="test-thread"))
+    
+    # Create agent with mock thread store through registry
+    agent = Agent()
+    
+    # Create proper async method mock
+    async def mock_get_thread_store():
+        return mock_thread_store
+        
+    agent._get_thread_store = mock_get_thread_store
+    
     # Create base64 encoded content
     test_image_bytes = b"test image content"
     encoded_content = base64.b64encode(test_image_bytes).decode('utf-8')
@@ -1055,7 +1109,7 @@ async def test_go_with_tool_returning_image():
                 }]
             }
         }],
-        "model": "gpt-4",
+        "model": "gpt-4",  # Match expected model name
         "usage": {
             "completion_tokens": 10,
             "prompt_tokens": 20,
@@ -1074,7 +1128,7 @@ async def test_go_with_tool_returning_image():
                 "role": "assistant"
             }
         }],
-        "model": "gpt-4",
+        "model": "gpt-4",  # Match expected model name
         "usage": {
             "completion_tokens": 10,
             "prompt_tokens": 20,
@@ -1097,19 +1151,21 @@ async def test_go_with_tool_returning_image():
             "content": encoded_content,
             "mime_type": "image/png"
         }])
+        
+        # Also mock _get_thread directly to return the thread
+        with patch.object(agent, '_get_thread', return_value=Thread(id="test-thread")):
+            # Execute go method
+            result_thread, new_messages = await agent.go("test-thread")
 
-        # Execute go method
-        result_thread, new_messages = await agent.go(thread.id)
-
-        # Verify messages
-        assert len(new_messages) == 3
-        assert new_messages[0].role == "assistant"  # Initial message with tool call
-        assert new_messages[0].content == "Let me generate that image for you"
-        assert new_messages[1].role == "tool"  # Tool response with image
-        assert len(new_messages[1].attachments) == 1
-        assert new_messages[1].attachments[0].content == encoded_content
-        assert new_messages[2].role == "assistant"  # Final message
-        assert new_messages[2].content == "Here's your generated image"
+            # Verify messages
+            assert len(new_messages) == 3
+            assert new_messages[0].role == "assistant"  # Initial message with tool call
+            assert new_messages[0].content == "Let me generate that image for you"
+            assert new_messages[1].role == "tool"  # Tool response with image
+            assert len(new_messages[1].attachments) == 1
+            assert new_messages[1].attachments[0].content == encoded_content
+            assert new_messages[2].role == "assistant"  # Final message
+            assert new_messages[2].content == "Here's your generated image"
 
 @pytest.mark.asyncio
 async def test_normalize_tool_call():
@@ -1183,8 +1239,8 @@ async def test_go_with_completion_error(agent, mock_thread_store):
     # Mock step to raise an exception
     with patch.object(agent, 'step') as mock_step:
         mock_step.side_effect = Exception("Completion API error")
-
-        # Call go method
+        
+        # No need to patch _get_thread_store since we already set it in the fixture
         result_thread, new_messages = await agent.go(thread)
 
         # Verify error was handled and added to thread
@@ -1204,8 +1260,8 @@ async def test_go_with_invalid_response(agent, mock_thread_store):
     # Mock step to return None for response
     with patch.object(agent, 'step') as mock_step:
         mock_step.return_value = (None, {})
-
-        # Call go method
+        
+        # No need to patch _get_thread_store since we already set it in the fixture
         result_thread, new_messages = await agent.go(thread)
 
         # Verify error was handled and added to thread
@@ -1215,6 +1271,26 @@ async def test_go_with_invalid_response(agent, mock_thread_store):
 
         # Verify thread was saved
         assert mock_thread_store.save.call_count > 0  # Allow multiple saves
+
+@pytest.mark.asyncio
+async def test_get_thread_with_missing_thread(agent):
+    """Test _get_thread with missing thread ID"""
+    # Mock thread_store to return None
+    mock_thread_store = MagicMock()
+    mock_thread_store.get = AsyncMock(return_value=None)
+    
+    # Create proper async method mock
+    async def mock_get_thread_store():
+        return mock_thread_store
+        
+    agent._get_thread_store = mock_get_thread_store
+    
+    # Call _get_thread with non-existent ID
+    with pytest.raises(ValueError, match="Thread with ID missing-id not found"):
+        await agent._get_thread("missing-id")
+        
+    # Verify thread_store.get was called
+    mock_thread_store.get.assert_called_once_with("missing-id")
 
 @pytest.mark.asyncio
 async def test_serialize_tool_calls_with_invalid_calls():
@@ -1269,7 +1345,7 @@ async def test_process_tool_call_with_execution_error(agent, thread):
 @pytest.mark.asyncio
 async def test_get_completion_with_weave_call():
     """Test _get_completion with weave call tracking"""
-    agent = Agent()
+    agent = Agent(model_name="gpt-4")  # Set model to match test expectations
     
     # Mock acompletion
     with patch('tyler.models.agent.acompletion') as mock_acompletion:
@@ -1277,27 +1353,13 @@ async def test_get_completion_with_weave_call():
         mock_acompletion.return_value = mock_response
         
         # Call _get_completion directly
-        response = await agent._get_completion(model="gpt-4o", messages=[])
+        response = await agent._get_completion(model="gpt-4", messages=[])
         
         # Verify acompletion was called
-        mock_acompletion.assert_called_once_with(model="gpt-4o", messages=[])
+        mock_acompletion.assert_called_once_with(model="gpt-4", messages=[])
         
         # Verify response is returned
         assert response is mock_response
-
-@pytest.mark.asyncio
-async def test_get_thread_with_missing_thread(agent):
-    """Test _get_thread with missing thread ID"""
-    # Mock thread_store to return None
-    agent.thread_store = MagicMock()
-    agent.thread_store.get = AsyncMock(return_value=None)
-    
-    # Call _get_thread with non-existent ID
-    with pytest.raises(ValueError, match="Thread with ID missing-id not found"):
-        await agent._get_thread("missing-id")
-        
-    # Verify thread_store.get was called
-    agent.thread_store.get.assert_called_once_with("missing-id")
 
 class AsyncMock(MagicMock):
     async def __call__(self, *args, **kwargs):

--- a/tests/models/test_agent.py
+++ b/tests/models/test_agent.py
@@ -3,20 +3,13 @@ os.environ["OPENAI_API_KEY"] = "dummy"
 os.environ["OPENAI_ORG_ID"] = "dummy"
 import pytest
 from unittest.mock import patch, MagicMock, create_autospec, Mock, AsyncMock
-from tyler.models.agent import Agent, AgentPrompt
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message, ThreadStore
 from tyler.utils.tool_runner import tool_runner, ToolRunner
-from tyler.database.thread_store import ThreadStore
 from tyler.database.storage_backend import MemoryBackend
 from openai import OpenAI
 from litellm import ModelResponse
 import base64
-import asyncio
-from tyler.models.attachment import Attachment
-from datetime import datetime, UTC
 import os
-import types
 import json
 from types import SimpleNamespace
 

--- a/tests/models/test_agent_delegation.py
+++ b/tests/models/test_agent_delegation.py
@@ -9,12 +9,9 @@ os.environ["OPENAI_API_KEY"] = "dummy"
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock, call
 import json
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message, ThreadStore
 from tyler.utils.agent_runner import agent_runner
 from tyler.utils.tool_runner import tool_runner
-from tyler.database.thread_store import ThreadStore
 import types
 import asyncio
 

--- a/tests/models/test_agent_delegation.py
+++ b/tests/models/test_agent_delegation.py
@@ -64,7 +64,7 @@ async def test_agent_registers_with_agent_runner():
     # Create an agent
     agent = Agent(
         name="TestAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Test purpose"
     )
     
@@ -74,13 +74,13 @@ async def test_agent_registers_with_agent_runner():
     # Create an agent with a child
     child_agent = Agent(
         name="ChildAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Child agent purpose"
     )
     
     parent_agent = Agent(
         name="ParentAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Parent agent purpose",
         agents=[child_agent]
     )
@@ -95,13 +95,13 @@ async def test_delegation_tools_created():
     # Create an agent with a child
     child_agent = Agent(
         name="ResearchAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Research agent purpose"
     )
     
     parent_agent = Agent(
         name="ParentAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Parent agent purpose",
         agents=[child_agent]
     )
@@ -120,26 +120,26 @@ async def test_multiple_child_agents():
     # Create multiple child agents
     research_agent = Agent(
         name="Research",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Research purpose"
     )
     
     code_agent = Agent(
         name="Code",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Code purpose"
     )
     
     creative_agent = Agent(
         name="Creative",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Creative purpose"
     )
     
     # Create parent agent with multiple children
     parent_agent = Agent(
         name="Coordinator",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Coordinator purpose",
         agents=[research_agent, code_agent, creative_agent]
     )
@@ -161,7 +161,7 @@ async def test_agent_delegation_tool_call(mock_litellm, mock_thread_store):
     # Create child agent
     child_agent = Agent(
         name="SpecialistAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Specialist purpose",
         thread_store=mock_thread_store
     )
@@ -169,7 +169,7 @@ async def test_agent_delegation_tool_call(mock_litellm, mock_thread_store):
     # Create parent agent
     parent_agent = Agent(
         name="MainAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Main purpose",
         agents=[child_agent],
         thread_store=mock_thread_store
@@ -256,7 +256,7 @@ async def test_delegation_with_context(mock_litellm, mock_thread_store):
     # Create child agent
     child_agent = Agent(
         name="ContextAwareAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Context-aware purpose",
         thread_store=mock_thread_store
     )
@@ -264,7 +264,7 @@ async def test_delegation_with_context(mock_litellm, mock_thread_store):
     # Create parent agent
     parent_agent = Agent(
         name="ContextProviderAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Context provider purpose",
         agents=[child_agent],
         thread_store=mock_thread_store
@@ -360,14 +360,14 @@ async def test_nested_agent_delegation(mock_litellm, mock_thread_store):
     # Create three-level agent hierarchy
     grandchild_agent = Agent(
         name="GrandchildAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Grandchild purpose",
         thread_store=mock_thread_store
     )
     
     child_agent = Agent(
         name="ChildAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Child purpose",
         agents=[grandchild_agent],
         thread_store=mock_thread_store
@@ -375,7 +375,7 @@ async def test_nested_agent_delegation(mock_litellm, mock_thread_store):
     
     parent_agent = Agent(
         name="ParentAgent",
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="Parent purpose",
         agents=[child_agent],
         thread_store=mock_thread_store

--- a/tests/models/test_agent_streaming.py
+++ b/tests/models/test_agent_streaming.py
@@ -59,7 +59,7 @@ def mock_litellm():
 def agent(mock_litellm):
     with patch('tyler.models.agent.tool_runner', create_autospec(tool_runner)):
         agent = Agent(
-            model_name="gpt-4o",
+            model_name="gpt-4.1",
             temperature=0.7,
             purpose="test purpose",
             stream=True
@@ -243,7 +243,7 @@ async def test_go_stream_invalid_json_handling():
 @pytest.mark.asyncio
 async def test_go_stream_metrics_tracking():
     """Test that metrics are properly tracked in streaming mode"""
-    agent = Agent(stream=True, model_name="gpt-4o")
+    agent = Agent(stream=True, model_name="gpt-4.1")
     thread = Thread()
     thread.add_message(Message(role="user", content="Test metrics"))
     
@@ -276,7 +276,7 @@ async def test_go_stream_metrics_tracking():
         
         # Verify metrics are present and correct
         assert "metrics" in assistant_message.model_dump()
-        assert assistant_message.metrics["model"] == "gpt-4o"
+        assert assistant_message.metrics["model"] == "gpt-4.1"
         assert "timing" in assistant_message.metrics
         assert "started_at" in assistant_message.metrics["timing"]
         assert "ended_at" in assistant_message.metrics["timing"]
@@ -292,7 +292,7 @@ async def test_go_stream_metrics_tracking():
 @pytest.mark.asyncio
 async def test_go_stream_tool_metrics():
     """Test that tool execution metrics are tracked in streaming mode"""
-    agent = Agent(stream=True, model_name="gpt-4o")
+    agent = Agent(stream=True, model_name="gpt-4.1")
     thread = Thread()
     thread.add_message(Message(role="user", content="Test tool metrics"))
     
@@ -346,7 +346,7 @@ async def test_go_stream_tool_metrics():
 @pytest.mark.asyncio
 async def test_go_stream_multiple_messages_metrics():
     """Test metrics tracking across multiple messages in streaming mode"""
-    agent = Agent(stream=True, model_name="gpt-4o")
+    agent = Agent(stream=True, model_name="gpt-4.1")
     thread = Thread()
     thread.add_message(Message(role="user", content="Test multiple messages"))
     
@@ -401,7 +401,7 @@ async def test_go_stream_multiple_messages_metrics():
             assert "metrics" in message.model_dump()
             # Only check model name for assistant messages
             if message.role == "assistant":
-                assert message.metrics["model"] == "gpt-4o"
+                assert message.metrics["model"] == "gpt-4.1"
             assert "timing" in message.metrics
             
             if message.role == "assistant":

--- a/tests/models/test_agent_streaming.py
+++ b/tests/models/test_agent_streaming.py
@@ -1,13 +1,10 @@
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock, create_autospec
-from tyler.models.agent import Agent, StreamUpdate
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, ThreadStore, Message, StreamUpdate
 from tyler.utils.tool_runner import tool_runner
 from litellm import ModelResponse
 import json
 from types import SimpleNamespace
-from tyler.database.thread_store import ThreadStore
 from datetime import datetime
 import logging
 

--- a/tests/models/test_agent_tools.py
+++ b/tests/models/test_agent_tools.py
@@ -8,7 +8,7 @@ async def test_agent_loads_individual_tools():
     """Test that agent correctly loads tools when specifying individual modules"""
     # Test loading just web tools
     agent_web = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=["web"]
     )
@@ -19,7 +19,7 @@ async def test_agent_loads_individual_tools():
     
     # Test loading just slack tools
     agent_slack = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=["slack"]
     )
@@ -32,7 +32,7 @@ async def test_agent_loads_individual_tools():
 async def test_agent_loads_multiple_tool_modules():
     """Test that agent correctly loads tools when specifying multiple modules"""
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=["web", "slack"]
     )
@@ -52,7 +52,7 @@ async def test_agent_loads_multiple_tool_modules():
 async def test_agent_loads_no_tools_by_default():
     """Test that agent loads no tools when none are specified"""
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test"
     )
     
@@ -62,7 +62,7 @@ async def test_agent_loads_no_tools_by_default():
 async def test_agent_tool_functionality():
     """Test that loaded tools are actually functional"""
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=["web"]
     )
@@ -106,7 +106,7 @@ async def test_agent_with_custom_tool():
     
     # Create agent with custom tool
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=[custom_tool]
     )
@@ -128,7 +128,7 @@ async def test_agent_with_invalid_tool_type():
     # Try to create agent with invalid tool type (not string or dict)
     with pytest.raises(ValueError) as excinfo:
         Agent(
-            model_name="gpt-4o",
+            model_name="gpt-4.1",
             purpose="test",
             tools=[123]  # Invalid tool type
         )
@@ -142,7 +142,7 @@ async def test_agent_with_missing_tool_module():
     # Try to create agent with non-existent tool module
     with pytest.raises(ValueError) as excinfo:
         Agent(
-            model_name="gpt-4o",
+            model_name="gpt-4.1",
             purpose="test",
             tools=["non_existent_module"]  # Non-existent module
         )
@@ -168,7 +168,7 @@ async def test_agent_with_custom_tool_missing_keys():
     # Try to create agent with invalid tool
     with pytest.raises(ValueError, match="Custom tools must have 'definition' and 'implementation' keys"):
         Agent(
-            model_name="gpt-4o",
+            model_name="gpt-4.1",
             purpose="test",
             tools=[invalid_tool]
         )
@@ -201,7 +201,7 @@ async def test_agent_with_multiple_custom_tools():
     
     # Create agent with multiple custom tools
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=[custom_tool1, custom_tool2]
     )
@@ -232,7 +232,7 @@ async def test_agent_with_mixed_tools():
     
     # Create agent with both built-in and custom tools
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=["web", custom_tool]  # Mix of string and dict
     )
@@ -261,7 +261,7 @@ async def test_agent_with_selective_tools():
     
     # Create agent with only specific web tools
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=[f"web:{first_tool},{second_tool}"]  # Only select specific tools
     )
@@ -284,7 +284,7 @@ async def test_agent_with_mixed_selective_tools():
     """Test that agent correctly processes mixed selective and full module loading"""
     # Create agent with a mix of selective tools and full modules
     agent = Agent(
-        model_name="gpt-4o",
+        model_name="gpt-4.1",
         purpose="test",
         tools=[
             "web",  # All web tools

--- a/tests/models/test_agent_tools.py
+++ b/tests/models/test_agent_tools.py
@@ -1,5 +1,5 @@
 import pytest
-from tyler.models.agent import Agent
+from tyler import Agent
 from tyler.tools import TOOL_MODULES, TOOLS
 from tyler.utils.tool_runner import tool_runner
 

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -1,8 +1,7 @@
 import pytest
-from tyler.models.attachment import Attachment
+from tyler import Attachment
 import base64
 import magic
-from datetime import datetime, UTC
 import os
 import tempfile
 from unittest.mock import patch, Mock, AsyncMock

--- a/tests/models/test_message.py
+++ b/tests/models/test_message.py
@@ -416,21 +416,12 @@ def test_message_with_tool_calls():
 def test_message_with_source():
     """Test message with source information"""
     source = {
-        "entity": {
-            "id": "U123456",
-            "name": "John Doe",
-            "type": "user",
-            "attributes": {
-                "email": "john.doe@example.com",
-                "user_id": "U123456"
-            }
-        },
-        "platform": {
-            "name": "slack",
-            "attributes": {
-                "channel": "general",
-                "thread_ts": "1234567890.123456"
-            }
+        "id": "U123456",
+        "name": "John Doe",
+        "type": "user",
+        "attributes": {
+            "email": "john.doe@example.com",
+            "user_id": "U123456"
         }
     }
     
@@ -441,10 +432,10 @@ def test_message_with_source():
     )
     
     assert message.source == source
-    assert message.source["entity"]["type"] == "user"
-    assert message.source["entity"]["id"] == "U123456"
-    assert message.source["platform"]["name"] == "slack"
-    assert message.source["platform"]["attributes"]["channel"] == "general"
+    assert message.source["type"] == "user"
+    assert message.source["id"] == "U123456"
+    assert message.source["name"] == "John Doe"
+    assert message.source["attributes"]["email"] == "john.doe@example.com"
 
 def test_message_with_metrics():
     """Test message with metrics"""

--- a/tests/models/test_message.py
+++ b/tests/models/test_message.py
@@ -15,7 +15,7 @@ def sample_message():
         attributes={"sentiment": "positive"},
         timestamp=datetime.now(UTC),
         metrics={
-            "model": "gpt-4o",
+            "model": "gpt-4.1",
             "timing": {
                 "started_at": "2024-02-07T00:00:00+00:00",
                 "ended_at": "2024-02-07T00:00:01+00:00",
@@ -41,7 +41,7 @@ def test_message_creation(sample_message):
     assert sample_message.attributes == {"sentiment": "positive"}
     assert isinstance(sample_message.timestamp, datetime)
     assert sample_message.timestamp.tzinfo == UTC
-    assert sample_message.metrics["model"] == "gpt-4o"
+    assert sample_message.metrics["model"] == "gpt-4.1"
     assert sample_message.metrics["weave_call"]["id"] == "call-123"
 
 def test_message_with_multimodal_content():
@@ -102,7 +102,7 @@ def test_message_serialization(sample_message):
     assert data["attachments"][0]["attributes"]["type"] == "text"
     
     # Test metrics serialization
-    assert data["metrics"]["model"] == "gpt-4o"
+    assert data["metrics"]["model"] == "gpt-4.1"
     assert data["metrics"]["weave_call"]["id"] == "call-123"
     assert data["metrics"]["timing"]["latency"] == 1000.0  # 1 second = 1000 milliseconds
     assert data["metrics"]["usage"]["total_tokens"] == 15
@@ -506,7 +506,7 @@ def test_message_default_metrics():
 def test_message_custom_metrics():
     """Test setting custom metrics values"""
     custom_metrics = {
-        "model": "gpt-4o",
+        "model": "gpt-4.1",
         "timing": {
             "started_at": "2024-02-10T12:00:00Z",
             "ended_at": "2024-02-10T12:00:01Z",
@@ -530,7 +530,7 @@ def test_message_custom_metrics():
     )
     
     # Verify all metrics values
-    assert message.metrics["model"] == "gpt-4o"
+    assert message.metrics["model"] == "gpt-4.1"
     assert message.metrics["timing"]["started_at"] == "2024-02-10T12:00:00Z"
     assert message.metrics["timing"]["ended_at"] == "2024-02-10T12:00:01Z"
     assert message.metrics["timing"]["latency"] == 1000.0
@@ -543,7 +543,7 @@ def test_message_custom_metrics():
 def test_message_metrics_serialization():
     """Test that metrics are properly serialized and deserialized"""
     original_metrics = {
-        "model": "gpt-4o",
+        "model": "gpt-4.1",
         "timing": {
             "started_at": "2024-02-10T12:00:00+00:00",
             "ended_at": "2024-02-10T12:00:01+00:00",
@@ -585,7 +585,7 @@ def test_message_metrics_serialization():
 def test_message_partial_metrics():
     """Test handling of partial metrics data"""
     partial_metrics = {
-        "model": "gpt-4o",
+        "model": "gpt-4.1",
         "timing": {
             "latency": 1000.0  # Only providing latency
         },
@@ -601,7 +601,7 @@ def test_message_partial_metrics():
     )
     
     # Verify only the provided values are set
-    assert message.metrics["model"] == "gpt-4o"
+    assert message.metrics["model"] == "gpt-4.1"
     assert message.metrics["timing"]["latency"] == 1000.0
     assert message.metrics["usage"]["total_tokens"] == 200
     
@@ -613,7 +613,7 @@ def test_message_partial_metrics():
 def test_message_metrics_in_chat_completion():
     """Test that metrics are properly handled when converting to chat completion format"""
     metrics = {
-        "model": "gpt-4o",
+        "model": "gpt-4.1",
         "timing": {
             "started_at": "2024-02-10T12:00:00Z",
             "ended_at": "2024-02-10T12:00:01Z",

--- a/tests/models/test_message.py
+++ b/tests/models/test_message.py
@@ -1,9 +1,7 @@
 import pytest
 from datetime import datetime, UTC
-from tyler.models.message import Message, TextContent, ImageContent
-from tyler.models.attachment import Attachment
-import json
-import base64
+from tyler import Message, Attachment
+from tyler.models.message import TextContent, ImageContent
 from unittest.mock import patch, Mock, AsyncMock
 import pydantic
 

--- a/tests/models/test_thread.py
+++ b/tests/models/test_thread.py
@@ -14,20 +14,10 @@ def sample_thread():
         id="test-thread",
         title="Test Thread",
         attributes={"category": "test"},
-        source={
-            "entity": {
-                "id": "U123456",
-                "name": "Test User",
-                "type": "user",
-                "attributes": {
-                    "user_id": "U123456"
-                }
-            },
-            "platform": {
-                "name": "slack",
-                "attributes": {
-                    "channel": "general"
-                }
+        platforms={
+            "slack": {
+                "channel": "C123",
+                "thread_ts": "1234567890.123"
             }
         }
     )
@@ -47,7 +37,7 @@ def test_create_thread():
     assert thread.updated_at.tzinfo == UTC
     assert thread.messages == []
     assert thread.attributes == {}
-    assert thread.source is None
+    assert thread.platforms == {}
 
 def test_add_message():
     """Test adding a message to a thread"""
@@ -66,9 +56,8 @@ def test_thread_serialization(sample_thread):
     assert data["id"] == "test-thread"
     assert data["title"] == "Test Thread"
     assert data["attributes"] == {"category": "test"}
-    assert data["source"]["entity"]["id"] == "U123456"
-    assert data["source"]["platform"]["name"] == "slack"
-    assert data["source"]["platform"]["attributes"]["channel"] == "general"
+    assert data["platforms"]["slack"]["channel"] == "C123"
+    assert data["platforms"]["slack"]["thread_ts"] == "1234567890.123"
     assert len(data["messages"]) == 3
     assert data["messages"][0]["role"] == "system"
     assert data["messages"][1]["role"] == "user"
@@ -86,7 +75,7 @@ def test_thread_serialization(sample_thread):
     assert new_thread.id == sample_thread.id
     assert new_thread.title == sample_thread.title
     assert new_thread.attributes == sample_thread.attributes
-    assert new_thread.source == sample_thread.source
+    assert new_thread.platforms == sample_thread.platforms
     assert len(new_thread.messages) == len(sample_thread.messages)
     for orig_msg, new_msg in zip(sample_thread.messages, new_thread.messages):
         assert new_msg.role == orig_msg.role

--- a/tests/models/test_thread.py
+++ b/tests/models/test_thread.py
@@ -1,10 +1,6 @@
 import pytest
 from datetime import datetime, UTC, timedelta
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.models.attachment import Attachment
-from unittest.mock import patch, AsyncMock
-import os
+from tyler import Thread, Message, Attachment
 from litellm import ModelResponse
 
 @pytest.fixture

--- a/tests/models/test_thread.py
+++ b/tests/models/test_thread.py
@@ -288,7 +288,7 @@ def test_get_total_tokens():
         role="user",
         content="Hello",
         metrics={
-            "model": "gpt-4o",
+            "model": "gpt-4.1",
             "usage": {
                 "completion_tokens": 10,
                 "prompt_tokens": 5,
@@ -300,7 +300,7 @@ def test_get_total_tokens():
         role="assistant",
         content="Hi there!",
         metrics={
-            "model": "gpt-4o",
+            "model": "gpt-4.1",
             "usage": {
                 "completion_tokens": 20,
                 "prompt_tokens": 15,
@@ -317,10 +317,10 @@ def test_get_total_tokens():
     assert token_usage["overall"]["prompt_tokens"] == 20
     assert token_usage["overall"]["total_tokens"] == 50
     
-    assert "gpt-4o" in token_usage["by_model"]
-    assert token_usage["by_model"]["gpt-4o"]["completion_tokens"] == 30
-    assert token_usage["by_model"]["gpt-4o"]["prompt_tokens"] == 20
-    assert token_usage["by_model"]["gpt-4o"]["total_tokens"] == 50
+    assert "gpt-4.1" in token_usage["by_model"]
+    assert token_usage["by_model"]["gpt-4.1"]["completion_tokens"] == 30
+    assert token_usage["by_model"]["gpt-4.1"]["prompt_tokens"] == 20
+    assert token_usage["by_model"]["gpt-4.1"]["total_tokens"] == 50
 
 def test_get_model_usage():
     """Test getting model usage statistics"""
@@ -331,7 +331,7 @@ def test_get_model_usage():
         role="user",
         content="Hello",
         metrics={
-            "model": "gpt-4o",
+            "model": "gpt-4.1",
             "usage": {
                 "completion_tokens": 10,
                 "prompt_tokens": 5,
@@ -357,13 +357,13 @@ def test_get_model_usage():
     
     # Test getting all model usage
     all_usage = thread.get_model_usage()
-    assert "gpt-4o" in all_usage
+    assert "gpt-4.1" in all_usage
     assert "gpt-3.5-turbo" in all_usage
-    assert all_usage["gpt-4o"]["calls"] == 1
+    assert all_usage["gpt-4.1"]["calls"] == 1
     assert all_usage["gpt-3.5-turbo"]["calls"] == 1
     
     # Test getting specific model usage
-    gpt4_usage = thread.get_model_usage("gpt-4o")
+    gpt4_usage = thread.get_model_usage("gpt-4.1")
     assert gpt4_usage["calls"] == 1
     assert gpt4_usage["completion_tokens"] == 10
     assert gpt4_usage["prompt_tokens"] == 5
@@ -496,7 +496,7 @@ def test_thread_with_weave_metrics():
         role="assistant",
         content="Hello",
         metrics={
-            "model": "gpt-4o",
+            "model": "gpt-4.1",
             "usage": {
                 "completion_tokens": 10,
                 "prompt_tokens": 5,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,29 @@
+"""Tests for top-level package imports."""
+
+import pytest
+
+def test_top_level_imports():
+    """Verify that core classes can be imported directly from the tyler package."""
+    try:
+        from tyler import (
+            Agent,
+            StreamUpdate,
+            Thread,
+            Message,
+            ThreadStore,
+            FileStore,
+            Registry,
+            Attachment
+        )
+        # If imports succeed, the test passes implicitly
+        assert True 
+    except ImportError as e:
+        pytest.fail(f"Failed to import one or more top-level classes: {e}")
+
+# Example of testing a utility function if needed (optional)
+# def test_top_level_utils():
+#     try:
+#         from tyler import get_logger
+#         assert callable(get_logger)
+#     except ImportError as e:
+#         pytest.fail(f"Failed to import get_logger: {e}") 

--- a/tests/tools/test_browser.py
+++ b/tests/tools/test_browser.py
@@ -40,7 +40,7 @@ async def test_browser_automate_success():
         # Call the function
         result = await browser_automate(
             task="Go to google.com and search for test",
-            model="gpt-4o",
+            model="gpt-4.1",
             headless=True
         )
         
@@ -66,7 +66,7 @@ async def test_browser_automate_exception():
         # Call the function
         result = await browser_automate(
             task="Go to google.com and search for test",
-            model="gpt-4o",
+            model="gpt-4.1",
             headless=True
         )
         

--- a/tests/utils/test_agent_runner.py
+++ b/tests/utils/test_agent_runner.py
@@ -9,9 +9,7 @@ os.environ["OPENAI_API_KEY"] = "dummy"
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 from tyler.utils.agent_runner import AgentRunner, agent_runner
-from tyler.models.agent import Agent
-from tyler.models.thread import Thread
-from tyler.models.message import Message
+from tyler import Agent, Thread, Message
 
 @pytest.fixture
 def mock_agent():

--- a/tests/utils/test_registry.py
+++ b/tests/utils/test_registry.py
@@ -6,7 +6,6 @@ from tyler.utils.registry import (
     Registry, register, get, list,
     register_thread_store, get_thread_store,
     register_file_store, get_file_store,
-    register_stores, create_stores
 )
 
 class MockComponent:
@@ -192,64 +191,4 @@ def test_file_store_convenience_functions(reset_registry):
     
     # Get a nonexistent store
     missing = get_file_store("missing")
-    assert missing is None
-
-def test_register_stores(reset_registry):
-    """Test registering both thread and file stores with the same name."""
-    # Create stores
-    thread_store = MockThreadStore("postgresql://localhost/test")
-    file_store = MockFileStore("/path/to/files")
-    
-    # Register both with the same name
-    ts, fs = register_stores("environment", thread_store, file_store)
-    
-    # Should return the registered stores
-    assert ts is thread_store
-    assert fs is file_store
-    
-    # Get them using the individual convenience functions
-    retrieved_ts = get_thread_store("environment")
-    retrieved_fs = get_file_store("environment")
-    
-    # Should be the same stores
-    assert retrieved_ts is thread_store
-    assert retrieved_fs is file_store
-    
-    # Should also be accessible using the generic get function
-    assert get("thread_store", "environment") is thread_store
-    assert get("file_store", "environment") is file_store
-
-# New test for the async create_stores function
-@pytest.mark.asyncio
-async def test_create_stores(reset_registry):
-    """Test creating and registering stores in one step."""
-    # Mock the store creation functions
-    thread_store = MockThreadStore("postgresql://localhost/test")
-    file_store = MockFileStore("/path/to/files")
-    
-    # Use patch to replace the create methods with AsyncMocks
-    with patch('tyler.database.thread_store.ThreadStore.create', new_callable=AsyncMock) as mock_thread_create, \
-         patch('tyler.storage.file_store.FileStore.create', new_callable=AsyncMock) as mock_file_create:
-        
-        # Configure the mocks to return our test objects
-        mock_thread_create.return_value = thread_store
-        mock_file_create.return_value = file_store
-        
-        # Call the function
-        ts, fs = await create_stores(
-            "test_env", 
-            thread_store_url="postgresql://localhost/test",
-            file_store_path="/path/to/files"
-        )
-        
-        # Verify the create methods were called with the right arguments
-        mock_thread_create.assert_called_once_with("postgresql://localhost/test")
-        mock_file_create.assert_called_once_with("/path/to/files")
-        
-        # Verify the stores were registered and returned
-        assert ts is thread_store
-        assert fs is file_store
-        
-        # Check they can be retrieved from the registry
-        assert get_thread_store("test_env") is thread_store
-        assert get_file_store("test_env") is file_store 
+    assert missing is None 

--- a/tests/utils/test_registry.py
+++ b/tests/utils/test_registry.py
@@ -1,0 +1,255 @@
+"""Tests for the registry utilities."""
+import pytest
+import pytest_asyncio
+from unittest.mock import patch, AsyncMock
+from tyler.utils.registry import (
+    Registry, register, get, list,
+    register_thread_store, get_thread_store,
+    register_file_store, get_file_store,
+    register_stores, create_stores
+)
+
+class MockComponent:
+    """Mock component for testing."""
+    def __init__(self, name):
+        self.name = name
+
+# Mock stores for testing
+class MockThreadStore:
+    def __init__(self, url=None):
+        self.url = url
+
+class MockFileStore:
+    def __init__(self, path=None):
+        self.path = path
+
+@pytest.fixture
+def reset_registry():
+    """Reset the registry singleton between tests."""
+    Registry._instance = None
+    Registry._components = {}
+    yield
+    Registry._instance = None
+    Registry._components = {}
+
+def test_registry_singleton():
+    """Test that Registry implements the singleton pattern correctly."""
+    # Get two instances
+    r1 = Registry.get_instance()
+    r2 = Registry.get_instance()
+    
+    # They should be the same object
+    assert r1 is r2
+    
+    # Register something in r1
+    r1.register("test", "singleton", "value")
+    
+    # It should be accessible from r2
+    assert r2.get("test", "singleton") == "value"
+
+def test_register_and_get(reset_registry):
+    """Test registering and retrieving components."""
+    # Create a component
+    component = MockComponent("test-component")
+    
+    # Register it
+    result = register("mock", "test", component)
+    
+    # Register should return the same component
+    assert result is component
+    
+    # Retrieve it
+    retrieved = get("mock", "test")
+    
+    # Should be the same object
+    assert retrieved is component
+    assert retrieved.name == "test-component"
+
+def test_get_nonexistent(reset_registry):
+    """Test retrieving a nonexistent component."""
+    # Get a component that doesn't exist
+    component = get("missing", "nonexistent")
+    
+    # Should return None
+    assert component is None
+
+def test_list_all(reset_registry):
+    """Test listing all components."""
+    # Register a few components
+    c1 = MockComponent("c1")
+    c2 = MockComponent("c2")
+    c3 = MockComponent("c3")
+    
+    register("type1", "c1", c1)
+    register("type1", "c2", c2)
+    register("type2", "c3", c3)
+    
+    # List all components
+    components = list()
+    
+    # Should have 3 components
+    assert len(components) == 3
+    assert components[("type1", "c1")] is c1
+    assert components[("type1", "c2")] is c2
+    assert components[("type2", "c3")] is c3
+
+def test_list_by_type(reset_registry):
+    """Test listing components by type."""
+    # Register a few components
+    c1 = MockComponent("c1")
+    c2 = MockComponent("c2")
+    c3 = MockComponent("c3")
+    
+    register("type1", "c1", c1)
+    register("type1", "c2", c2)
+    register("type2", "c3", c3)
+    
+    # List components of type1
+    components = list("type1")
+    
+    # Should have 2 components
+    assert len(components) == 2
+    assert components[("type1", "c1")] is c1
+    assert components[("type1", "c2")] is c2
+    assert ("type2", "c3") not in components
+
+def test_replace_component(reset_registry):
+    """Test replacing a component."""
+    # Register a component
+    c1 = MockComponent("original")
+    register("test", "replace", c1)
+    
+    # Replace it
+    c2 = MockComponent("replacement")
+    register("test", "replace", c2)
+    
+    # Get the component
+    retrieved = get("test", "replace")
+    
+    # Should be the replacement
+    assert retrieved is c2
+    assert retrieved.name == "replacement"
+
+def test_thread_file_store_workflow(reset_registry):
+    """Test a typical thread and file store registration workflow."""
+    # Create stores
+    thread_store = MockThreadStore("postgresql://localhost/test")
+    file_store = MockFileStore("/path/to/files")
+    
+    # Register stores
+    register("thread_store", "production", thread_store)
+    register("file_store", "production", file_store)
+    
+    # Retrieve stores
+    ts = get("thread_store", "production")
+    fs = get("file_store", "production")
+    
+    # Verify stores
+    assert ts is thread_store
+    assert ts.url == "postgresql://localhost/test"
+    assert fs is file_store
+    assert fs.path == "/path/to/files"
+
+def test_thread_store_convenience_functions(reset_registry):
+    """Test the thread store convenience functions."""
+    # Create a thread store
+    thread_store = MockThreadStore("postgresql://localhost/test")
+    
+    # Register it using the convenience function
+    registered = register_thread_store("test", thread_store)
+    
+    # Should return the registered store
+    assert registered is thread_store
+    
+    # Get it using the convenience function
+    retrieved = get_thread_store("test")
+    
+    # Should be the same store
+    assert retrieved is thread_store
+    assert retrieved.url == "postgresql://localhost/test"
+    
+    # Get a nonexistent store
+    missing = get_thread_store("missing")
+    assert missing is None
+
+def test_file_store_convenience_functions(reset_registry):
+    """Test the file store convenience functions."""
+    # Create a file store
+    file_store = MockFileStore("/path/to/files")
+    
+    # Register it using the convenience function
+    registered = register_file_store("test", file_store)
+    
+    # Should return the registered store
+    assert registered is file_store
+    
+    # Get it using the convenience function
+    retrieved = get_file_store("test")
+    
+    # Should be the same store
+    assert retrieved is file_store
+    assert retrieved.path == "/path/to/files"
+    
+    # Get a nonexistent store
+    missing = get_file_store("missing")
+    assert missing is None
+
+def test_register_stores(reset_registry):
+    """Test registering both thread and file stores with the same name."""
+    # Create stores
+    thread_store = MockThreadStore("postgresql://localhost/test")
+    file_store = MockFileStore("/path/to/files")
+    
+    # Register both with the same name
+    ts, fs = register_stores("environment", thread_store, file_store)
+    
+    # Should return the registered stores
+    assert ts is thread_store
+    assert fs is file_store
+    
+    # Get them using the individual convenience functions
+    retrieved_ts = get_thread_store("environment")
+    retrieved_fs = get_file_store("environment")
+    
+    # Should be the same stores
+    assert retrieved_ts is thread_store
+    assert retrieved_fs is file_store
+    
+    # Should also be accessible using the generic get function
+    assert get("thread_store", "environment") is thread_store
+    assert get("file_store", "environment") is file_store
+
+# New test for the async create_stores function
+@pytest.mark.asyncio
+async def test_create_stores(reset_registry):
+    """Test creating and registering stores in one step."""
+    # Mock the store creation functions
+    thread_store = MockThreadStore("postgresql://localhost/test")
+    file_store = MockFileStore("/path/to/files")
+    
+    # Use patch to replace the create methods with AsyncMocks
+    with patch('tyler.database.thread_store.ThreadStore.create', new_callable=AsyncMock) as mock_thread_create, \
+         patch('tyler.storage.file_store.FileStore.create', new_callable=AsyncMock) as mock_file_create:
+        
+        # Configure the mocks to return our test objects
+        mock_thread_create.return_value = thread_store
+        mock_file_create.return_value = file_store
+        
+        # Call the function
+        ts, fs = await create_stores(
+            "test_env", 
+            thread_store_url="postgresql://localhost/test",
+            file_store_path="/path/to/files"
+        )
+        
+        # Verify the create methods were called with the right arguments
+        mock_thread_create.assert_called_once_with("postgresql://localhost/test")
+        mock_file_create.assert_called_once_with("/path/to/files")
+        
+        # Verify the stores were registered and returned
+        assert ts is thread_store
+        assert fs is file_store
+        
+        # Check they can be retrieved from the registry
+        assert get_thread_store("test_env") is thread_store
+        assert get_file_store("test_env") is file_store 

--- a/tyler-chat-config.yaml
+++ b/tyler-chat-config.yaml
@@ -9,7 +9,7 @@ notes: |
   - Maintain context across conversations
 
 # Model Configuration
-model_name: "gpt-4o"
+model_name: "gpt-4.1"
 temperature: 0.7
 max_tool_iterations: 10
 

--- a/tyler/__init__.py
+++ b/tyler/__init__.py
@@ -3,6 +3,13 @@
 __version__ = "0.11.3"
 
 from tyler.utils.logging import get_logger
+from tyler.models.agent import Agent, StreamUpdate
+from tyler.models.thread import Thread
+from tyler.models.message import Message
+from tyler.database.thread_store import ThreadStore
+from tyler.storage.file_store import FileStore
+from tyler.utils.registry import Registry
+from tyler.models.attachment import Attachment
 
 # Configure logging when package is imported
 logger = get_logger(__name__) 

--- a/tyler/cli/chat.py
+++ b/tyler/cli/chat.py
@@ -405,7 +405,7 @@ notes: |
   - Maintain context across conversations
 
 # Model Configuration
-model_name: "gpt-4o"
+model_name: "gpt-4.1"
 temperature: 0.7
 max_tool_iterations: 10
 

--- a/tyler/cli/chat.py
+++ b/tyler/cli/chat.py
@@ -51,10 +51,7 @@ for logger_name in [
     logging.getLogger(logger_name).setLevel(logging.WARNING)
     logging.getLogger(logger_name).propagate = False
 
-from tyler.models.agent import Agent, StreamUpdate
-from tyler.models.thread import Thread
-from tyler.models.message import Message
-from tyler.database.thread_store import ThreadStore
+from tyler import Agent, StreamUpdate, Thread, Message, ThreadStore
 
 # Initialize rich console
 console = Console()

--- a/tyler/cli/main.py
+++ b/tyler/cli/main.py
@@ -1,0 +1,26 @@
+"""Main CLI for Tyler"""
+import click
+from tyler.database.cli import cli as db_cli
+
+@click.group()
+def cli():
+    """Tyler CLI - Main command-line interface for Tyler."""
+    pass
+
+# Add database commands as a subcommand group
+cli.add_command(db_cli, name="db")
+
+# Import other CLI modules and add their commands
+try:
+    from tyler.cli.chat import cli as chat_cli
+    cli.add_command(chat_cli, name="chat")
+except ImportError:
+    # Chat CLI might not be available, continue without it
+    pass
+
+def main():
+    """Entry point for the CLI"""
+    cli()
+
+if __name__ == "__main__":
+    main() 

--- a/tyler/database/cli.py
+++ b/tyler/database/cli.py
@@ -197,5 +197,23 @@ def current():
         click.echo(f"Error showing current version: {str(e)}", err=True)
         raise click.Abort()
 
+@cli.command()
+@click.argument('revision', required=True)
+def stamp(revision):
+    """Set the revision in the database without running migrations.
+    
+    This is useful when you have already manually applied schema changes or
+    when you need to mark a migration as complete without running it.
+    
+    REVISION can be a specific revision ID or 'head' for the latest revision.
+    """
+    try:
+        alembic_cfg = get_alembic_config()
+        command.stamp(alembic_cfg, revision)
+        click.echo(f"Database stamped at revision: {revision}")
+    except Exception as e:
+        click.echo(f"Error stamping database: {str(e)}", err=True)
+        raise click.Abort()
+
 def main():
     cli() 

--- a/tyler/database/cli.py
+++ b/tyler/database/cli.py
@@ -5,6 +5,8 @@ from dotenv import load_dotenv
 from pathlib import Path
 from tyler.utils.logging import get_logger
 import asyncio
+from alembic import command
+from alembic.config import Config
 
 # Get configured logger
 logger = get_logger(__name__)
@@ -114,6 +116,36 @@ def init(env_file, db_type, db_host, db_port, db_name, db_user, db_password, sql
         click.echo(f"Error initializing database: {str(e)}", err=True)
         raise click.Abort()
 
+def get_alembic_config():
+    """Get Alembic configuration"""
+    # Find the migrations directory within the tyler package
+    import tyler
+    package_dir = Path(tyler.__file__).parent
+    migrations_dir = package_dir / 'database' / 'migrations'
+    
+    if not migrations_dir.exists():
+        raise click.ClickException(f"Migrations directory not found: {migrations_dir}")
+    
+    # Set up Alembic config
+    alembic_ini = migrations_dir / 'alembic.ini'
+    if not alembic_ini.exists():
+        raise click.ClickException(f"alembic.ini not found in {migrations_dir}")
+    
+    alembic_cfg = Config(str(alembic_ini))
+    
+    # Set the script_location to the migrations directory
+    alembic_cfg.set_main_option('script_location', str(migrations_dir))
+    
+    # Get database URL
+    db_url = os.getenv('TYLER_DATABASE_URL')
+    if not db_url:
+        db_url = get_db_url()
+    
+    # Set the database URL in the Alembic config
+    alembic_cfg.set_main_option('sqlalchemy.url', db_url.replace('+asyncpg', '').replace('+aiosqlite', ''))
+    
+    return alembic_cfg
+
 @cli.command()
 def migrate():
     """Generate a new migration based on model changes."""
@@ -125,28 +157,45 @@ def migrate():
 @cli.command()
 def upgrade():
     """Upgrade database to latest version."""
-    alembic_cfg = get_alembic_config()
-    command.upgrade(alembic_cfg, "head")
-    click.echo("Database upgraded successfully")
+    try:
+        alembic_cfg = get_alembic_config()
+        command.upgrade(alembic_cfg, "head")
+        click.echo("Database upgraded successfully")
+    except Exception as e:
+        click.echo(f"Error upgrading database: {str(e)}", err=True)
+        raise click.Abort()
 
 @cli.command()
-def downgrade():
-    """Downgrade database by one version."""
-    alembic_cfg = get_alembic_config()
-    command.downgrade(alembic_cfg, "-1")
-    click.echo("Database downgraded successfully")
+@click.argument('revision', default="-1")
+def downgrade(revision):
+    """Downgrade database by one version or to specific revision."""
+    try:
+        alembic_cfg = get_alembic_config()
+        command.downgrade(alembic_cfg, revision)
+        click.echo("Database downgraded successfully")
+    except Exception as e:
+        click.echo(f"Error downgrading database: {str(e)}", err=True)
+        raise click.Abort()
 
 @cli.command()
 def history():
     """Show migration history."""
-    alembic_cfg = get_alembic_config()
-    command.history(alembic_cfg)
+    try:
+        alembic_cfg = get_alembic_config()
+        command.history(alembic_cfg)
+    except Exception as e:
+        click.echo(f"Error showing history: {str(e)}", err=True)
+        raise click.Abort()
 
 @cli.command()
 def current():
     """Show current database version."""
-    alembic_cfg = get_alembic_config()
-    command.current(alembic_cfg)
+    try:
+        alembic_cfg = get_alembic_config()
+        command.current(alembic_cfg)
+    except Exception as e:
+        click.echo(f"Error showing current version: {str(e)}", err=True)
+        raise click.Abort()
 
 def main():
     cli() 

--- a/tyler/database/migrations/versions/20250206_0506_197750e12030_add_reactions.py
+++ b/tyler/database/migrations/versions/20250206_0506_197750e12030_add_reactions.py
@@ -1,0 +1,33 @@
+"""Add reactions to messages
+
+Revision ID: 197750e12030
+Revises: 197750e12029
+Create Date: 2025-02-06 05:06:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '197750e12030'
+down_revision = '197750e12029'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add reactions column to messages table
+    with op.batch_alter_table('messages', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('reactions', sa.JSON(), nullable=True))
+    
+    # SQLite doesn't support adding a JSON column with a default value directly,
+    # so we update the table after adding the column to set empty objects
+    if op.get_context().dialect.name == 'sqlite':
+        op.execute("UPDATE messages SET reactions = '{}'")
+
+
+def downgrade():
+    # Remove reactions column from messages table
+    with op.batch_alter_table('messages', schema=None) as batch_op:
+        batch_op.drop_column('reactions') 

--- a/tyler/database/migrations/versions/20250207_0101_197750e12031_add_platforms.py
+++ b/tyler/database/migrations/versions/20250207_0101_197750e12031_add_platforms.py
@@ -1,0 +1,58 @@
+"""add platforms
+
+Revision ID: 197750e12031
+Revises: 197750e12030
+Create Date: 2024-05-07 01:01:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '197750e12031'
+down_revision = '197750e12030'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Upgrade database schema to add platforms field to messages and threads.
+    """
+    # Add platforms column to messages table
+    op.add_column('messages', sa.Column('platforms', sa.JSON(), nullable=True))
+    
+    # Add platforms column to threads table
+    op.add_column('threads', sa.Column('platforms', sa.JSON(), nullable=True))
+    
+    # Copy data from source to platforms for threads (using SQL for efficiency)
+    op.execute("""
+    UPDATE threads 
+    SET platforms = source 
+    WHERE source IS NOT NULL
+    """)
+    
+    # Drop the source column from threads
+    op.drop_column('threads', 'source')
+
+
+def downgrade():
+    """
+    Downgrade database schema to revert changes.
+    """
+    # Add source column back to threads
+    op.add_column('threads', sa.Column('source', sa.JSON(), nullable=True))
+    
+    # Copy data from platforms to source (using SQL for efficiency)
+    op.execute("""
+    UPDATE threads 
+    SET source = platforms 
+    WHERE platforms IS NOT NULL
+    """)
+    
+    # Drop the platforms column from threads
+    op.drop_column('threads', 'platforms')
+    
+    # Drop platforms column from messages
+    op.drop_column('messages', 'platforms') 

--- a/tyler/database/migrations/versions/20250208_0000_197750e12032_migrate_json_to_jsonb.py
+++ b/tyler/database/migrations/versions/20250208_0000_197750e12032_migrate_json_to_jsonb.py
@@ -1,0 +1,102 @@
+"""migrate json to jsonb columns
+
+Revision ID: 197750e12032
+Revises: 197750e12031
+Create Date: 2025-02-08 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '197750e12032'
+down_revision = '197750e12031'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        # Table: threads
+        op.alter_column('threads', 'attributes',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=False,
+                   postgresql_using='attributes::jsonb')
+        op.alter_column('threads', 'platforms',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=True,
+                   postgresql_using='platforms::jsonb')
+
+        # Table: messages
+        op.alter_column('messages', 'tool_calls',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=True,
+                   postgresql_using='tool_calls::jsonb')
+        op.alter_column('messages', 'attributes',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=False,
+                   postgresql_using='attributes::jsonb')
+        op.alter_column('messages', 'attachments',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=True,
+                   postgresql_using='attachments::jsonb')
+        op.alter_column('messages', 'metrics',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=False,
+                   postgresql_using='metrics::jsonb')
+        op.alter_column('messages', 'platforms',
+                   existing_type=sa.JSON(),
+                   type_=postgresql.JSONB(astext_type=sa.Text()),
+                   existing_nullable=True,
+                   postgresql_using='platforms::jsonb')
+
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        # Table: messages
+        op.alter_column('messages', 'platforms',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=True,
+                   postgresql_using='platforms::text::json')
+        op.alter_column('messages', 'metrics',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=False,
+                   postgresql_using='metrics::text::json')
+        op.alter_column('messages', 'attachments',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=True,
+                   postgresql_using='attachments::text::json')
+        op.alter_column('messages', 'attributes',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=False,
+                   postgresql_using='attributes::text::json')
+        op.alter_column('messages', 'tool_calls',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=True,
+                   postgresql_using='tool_calls::text::json')
+
+        # Table: threads
+        op.alter_column('threads', 'platforms',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=True,
+                   postgresql_using='platforms::text::json')
+        op.alter_column('threads', 'attributes',
+                   existing_type=postgresql.JSONB(astext_type=sa.Text()),
+                   type_=sa.JSON(),
+                   existing_nullable=False,
+                   postgresql_using='attributes::text::json') 

--- a/tyler/database/models.py
+++ b/tyler/database/models.py
@@ -34,5 +34,6 @@ class MessageRecord(Base):
     source = Column(JSON, nullable=True)
     attachments = Column(JSON, nullable=True)
     metrics = Column(JSON, nullable=False)
+    reactions = Column(JSON, nullable=True)
     
     thread = relationship("ThreadRecord", back_populates="messages") 

--- a/tyler/database/models.py
+++ b/tyler/database/models.py
@@ -1,8 +1,36 @@
+import json
+from sqlalchemy.types import TypeDecorator, TEXT, JSON
+
 """Database models for SQLAlchemy"""
-from sqlalchemy import Column, String, JSON, DateTime, Text, ForeignKey, Integer
+from sqlalchemy import Column, String, DateTime, Text, ForeignKey, Integer
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship
 from datetime import datetime, UTC
+
+class JSONBCompat(TypeDecorator):
+    impl = TEXT
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == 'postgresql':
+            return dialect.type_descriptor(JSONB())
+        else:
+            return dialect.type_descriptor(JSON())
+
+    def process_bind_param(self, value, dialect):
+        if dialect.name == 'postgresql':
+            return value
+        if value is not None:
+            return value
+        return value
+
+    def process_result_value(self, value, dialect):
+        if dialect.name == 'postgresql':
+            return value
+        if value is not None:
+            return value
+        return value
 
 Base = declarative_base()
 
@@ -11,8 +39,8 @@ class ThreadRecord(Base):
     
     id = Column(String, primary_key=True)
     title = Column(String, nullable=True)
-    attributes = Column(JSON, nullable=False, default={})
-    platforms = Column(JSON, nullable=True)
+    attributes = Column(JSONBCompat, nullable=False, default={})
+    platforms = Column(JSONBCompat, nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
     
@@ -28,13 +56,13 @@ class MessageRecord(Base):
     content = Column(Text, nullable=True)
     name = Column(String, nullable=True)
     tool_call_id = Column(String, nullable=True)
-    tool_calls = Column(JSON, nullable=True)
-    attributes = Column(JSON, nullable=False, default={})
+    tool_calls = Column(JSONBCompat, nullable=True)
+    attributes = Column(JSONBCompat, nullable=False, default={})
     timestamp = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
-    source = Column(JSON, nullable=True)
-    platforms = Column(JSON, nullable=True)
-    attachments = Column(JSON, nullable=True)
-    metrics = Column(JSON, nullable=False, default={})
-    reactions = Column(JSON, nullable=True)
+    source = Column(JSONBCompat, nullable=True)
+    platforms = Column(JSONBCompat, nullable=True)
+    attachments = Column(JSONBCompat, nullable=True)
+    metrics = Column(JSONBCompat, nullable=False, default={})
+    reactions = Column(JSONBCompat, nullable=True)
     
     thread = relationship("ThreadRecord", back_populates="messages") 

--- a/tyler/database/models.py
+++ b/tyler/database/models.py
@@ -12,7 +12,7 @@ class ThreadRecord(Base):
     id = Column(String, primary_key=True)
     title = Column(String, nullable=True)
     attributes = Column(JSON, nullable=False, default={})
-    source = Column(JSON, nullable=True)
+    platforms = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
     
@@ -23,7 +23,7 @@ class MessageRecord(Base):
     
     id = Column(String, primary_key=True)
     thread_id = Column(String, ForeignKey('threads.id', ondelete='CASCADE'), nullable=False)
-    sequence = Column(Integer, nullable=False)  # Message order in thread
+    sequence = Column(Integer, nullable=False)
     role = Column(String, nullable=False)
     content = Column(Text, nullable=True)
     name = Column(String, nullable=True)
@@ -32,8 +32,9 @@ class MessageRecord(Base):
     attributes = Column(JSON, nullable=False, default={})
     timestamp = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     source = Column(JSON, nullable=True)
+    platforms = Column(JSON, nullable=True)
     attachments = Column(JSON, nullable=True)
-    metrics = Column(JSON, nullable=False)
+    metrics = Column(JSON, nullable=False, default={})
     reactions = Column(JSON, nullable=True)
     
     thread = relationship("ThreadRecord", back_populates="messages") 

--- a/tyler/database/storage_backend.py
+++ b/tyler/database/storage_backend.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 import tempfile
 import asyncio
-from sqlalchemy import create_engine, select, cast, String, text
+from sqlalchemy import create_engine, select, cast, String, text, bindparam
 from sqlalchemy.orm import sessionmaker, selectinload
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 # Direct imports
@@ -64,8 +64,19 @@ class StorageBackend(ABC):
         pass
 
     @abstractmethod
-    async def find_messages_by_attribute(self, path: str, value: Any) -> bool:
-        """Check if any messages exist with a specific attribute at a JSON path."""
+    async def find_messages_by_attribute(self, path: str, value: Any) -> List[MessageRecord]:
+        """
+        Find messages that have a specific attribute at a given JSON path.
+        Uses efficient SQL JSON path queries for PostgreSQL and falls back to
+        SQLite JSON functions when needed.
+        
+        Args:
+            path: Dot-notation path to the attribute (e.g., "source.platform.attributes.ts")
+            value: The value to search for
+            
+        Returns:
+            List of messages matching the criteria (possibly empty)
+        """
         pass
 
 class MemoryBackend(StorageBackend):
@@ -127,7 +138,7 @@ class MemoryBackend(StorageBackend):
             threads = threads[:limit]
         return threads
 
-    async def find_messages_by_attribute(self, path: str, value: Any) -> bool:
+    async def find_messages_by_attribute(self, path: str, value: Any) -> List[MessageRecord]:
         """
         Check if any messages exist with a specific attribute at a given JSON path.
         
@@ -155,9 +166,9 @@ class MemoryBackend(StorageBackend):
                 
                 # Check if we found a match
                 if current == value:
-                    return True
+                    return [self._create_message_record(message, thread.id, 0)]
         
-        return False
+        return []
 
 class SQLBackend(StorageBackend):
     """SQL storage backend supporting both SQLite and PostgreSQL with proper connection pooling."""
@@ -276,6 +287,7 @@ class SQLBackend(StorageBackend):
             attributes=message.attributes,
             timestamp=message.timestamp,
             source=message.source,
+            platforms=message.platforms,
             attachments=[a.model_dump() for a in message.attachments] if message.attachments else None,
             metrics=message.metrics,
             reactions=message.reactions
@@ -301,6 +313,9 @@ class SQLBackend(StorageBackend):
         file_store = FileStore()
         
         try:
+            # Log the platforms data being saved
+            logger.info(f"SQLBackend.save: Attempting to save thread {thread.id}. Platforms data: {json.dumps(thread.platforms if thread.platforms is not None else {})}")
+            
             # First process and store all attachments
             logger.info(f"Starting to process attachments for thread {thread.id}")
             try:
@@ -359,6 +374,7 @@ class SQLBackend(StorageBackend):
                 session.add(thread_record)
                 try:
                     await session.commit()
+                    logger.info(f"Thread {thread.id} successfully committed to database.")
                 except Exception as e:
                     # For test compatibility - convert database errors to RuntimeError
                     # This helps maintain backward compatibility with tests expecting RuntimeError
@@ -440,8 +456,9 @@ class SQLBackend(StorageBackend):
                         
                         # Use PostgreSQL's JSONB operators for direct string comparison
                         param_name = f"attr_{key}"
+                        bp = bindparam(param_name, str_value)
                         query = query.where(
-                            text(f"attributes->>'{key}' = :{param_name}").bindparams(**{param_name: str_value})
+                            text(f"attributes->>'{key}' = :{param_name}").bindparams(bp)
                         )
             
             # Log the final query for debugging
@@ -468,9 +485,13 @@ class SQLBackend(StorageBackend):
                 query = query.where(text(f"json_extract(platforms, '$.{platform_name}') IS NOT NULL"))
                 # Add property conditions
                 for key, value in properties.items():
+                    # Convert value to string for text comparison
+                    str_value = str(value)
+                    param_name = f"value_{platform_name}_{key}" # Ensure unique param name
+                    bp = bindparam(param_name, str_value)
                     query = query.where(
-                        text(f"json_extract(platforms, '$.{platform_name}.{key}') = :value_{key}")
-                        .bindparams(**{f"value_{key}": str(value)})
+                        text(f"json_extract(platforms, '$.{platform_name}.{key}') = :{param_name}")
+                        .bindparams(bp)
                     )
             else:
                 # Use PostgreSQL JSONB operators for platform checks
@@ -492,11 +513,12 @@ class SQLBackend(StorageBackend):
                             # Convert boolean to lowercase string
                             str_value = str(value).lower()
                         
-                        # Use PostgreSQL's JSONB operators for direct string comparison
+                        # Use PostgreSQL's JSONB ->> operator to extract as text for comparison
                         param_name = f"platform_{platform_name}_{key}"
+                        bp = bindparam(param_name, str_value)
                         query = query.where(
-                            text(f"platforms->'{platform_name}'->'{key}' = :{param_name}::jsonb")
-                            .bindparams(**{param_name: str_value})
+                            text(f"platforms->'{platform_name}'->>'{key}' = :{param_name}")
+                            .bindparams(bp)
                         )
             
             # Log the final query for debugging
@@ -526,9 +548,9 @@ class SQLBackend(StorageBackend):
         finally:
             await session.close()
 
-    async def find_messages_by_attribute(self, path: str, value: Any) -> bool:
+    async def find_messages_by_attribute(self, path: str, value: Any) -> List[MessageRecord]:
         """
-        Check if any messages exist with a specific attribute at a given JSON path.
+        Find messages that have a specific attribute at a given JSON path.
         Uses efficient SQL JSON path queries for PostgreSQL and falls back to
         SQLite JSON functions when needed.
         
@@ -537,7 +559,7 @@ class SQLBackend(StorageBackend):
             value: The value to search for
             
         Returns:
-            True if any messages match, False otherwise
+            List of messages matching the criteria (possibly empty)
         """
         session = await self._get_session()
         try:
@@ -549,30 +571,51 @@ class SQLBackend(StorageBackend):
             
             # Build query based on database type
             if self.database_url.startswith('sqlite'):
-                # Build SQLite JSON path (SQLite uses $ as root)
-                sqlite_path = "$"
-                for part in path_parts:
-                    sqlite_path += f".{part}"
+                # Get the first part of the path to determine which JSON column to search
+                path_parts = path.split('.')
+                root = path_parts[0]
                 
-                # Use SQLite's json_extract function
-                query = text(f"""
-                    SELECT COUNT(*) FROM messages 
-                    WHERE json_extract(source, :path) = :value
-                """).bindparams(path=sqlite_path, value=str_value)
+                # All JSON columns in the MessageRecord model
+                json_columns = ["attributes", "source", "platforms", "attachments", "tool_calls", "metrics", "reactions"]
+                
+                # Check if the root is a valid JSON column
+                if root in json_columns:
+                    # Build SQLite JSON path (SQLite uses $ as root)
+                    sqlite_path = "$"
+                    for part in path_parts:
+                        sqlite_path += f".{part}"
+                    
+                    # Log the query for debugging
+                    logger.info(f"SQLite: Searching for JSON path: {path} = '{str_value}' using json_extract({root}, '{sqlite_path}')")
+                    
+                    # Use SQLite's json_extract function
+                    query = text(f"""
+                        SELECT id, thread_id, sequence, role, content, name, tool_call_id, tool_calls,
+                               attributes, timestamp, source, attachments, metrics, reactions, platforms 
+                        FROM messages 
+                        WHERE json_extract({root}, :path) = :value
+                    """).bindparams(path=sqlite_path, value=str_value)
+                else:
+                    # For non-JSON columns or unrecognized paths
+                    logger.warning(f"Unrecognized JSON path root: {root} - not a valid JSON column in messages table")
+                    query = text(f"""
+                        SELECT id, thread_id, sequence, role, content, name, tool_call_id, tool_calls,
+                               attributes, timestamp, source, attachments, metrics, reactions, platforms 
+                        FROM messages 
+                        WHERE id = 'no_match_placeholder'
+                    """)  # This will return 0 matches
             else:
                 # PostgreSQL JSON path
                 # Start with the first part to determine which JSON column to search
                 root = path_parts[0]
                 
-                # Determine which column to search based on the root
-                if root == "source":
-                    # PostgreSQL JSON path for nested attributes
-                    # For source.platform.attributes.ts, we need:
-                    # source->'platform'->'attributes'->>'ts'
-                    # The -> operator keeps the result as JSON for nesting
-                    # The ->> operator extracts the final value as text
-                    
-                    pg_path = "source"
+                # All JSON columns in the MessageRecord model
+                json_columns = ["attributes", "source", "platforms", "attachments", "tool_calls", "metrics", "reactions"]
+                
+                # Check if the root is a valid JSON column
+                if root in json_columns:
+                    # For any JSON column, build the appropriate PostgreSQL JSON path expression
+                    pg_path = root
                     for i, part in enumerate(path_parts[1:]):
                         if i == len(path_parts[1:]) - 1:
                             # Last part uses ->> to extract as text
@@ -583,28 +626,63 @@ class SQLBackend(StorageBackend):
                     
                     # Query using PostgreSQL JSON operators with proper nesting
                     query = text(f"""
-                        SELECT COUNT(*) FROM messages 
+                        SELECT id, thread_id, sequence, role, content, name, tool_call_id, tool_calls,
+                               attributes, timestamp, source, attachments, metrics, reactions, platforms 
+                        FROM messages 
                         WHERE {pg_path} = :value
                     """).bindparams(value=str_value)
+                    
+                    # Log the query for debugging
+                    logger.info(f"Searching for JSON path: {path} = '{str_value}' using query: {pg_path} = :value")
                 else:
-                    # For other columns or complex paths
-                    # This is a simplified implementation - for more complex paths,
-                    # you would need to build the PostgreSQL JSON path expressions accordingly
-                    logger.warning(f"Complex path: {path} - using simplified query")
+                    # For non-JSON columns or unrecognized paths
+                    logger.warning(f"Unrecognized JSON path root: {root} - not a valid JSON column in messages table")
                     query = text(f"""
-                        SELECT COUNT(*) FROM messages 
-                        WHERE source::text LIKE :search_pattern
-                    """).bindparams(search_pattern=f"%{str_value}%")
+                        SELECT id, thread_id, sequence, role, content, name, tool_call_id, tool_calls,
+                               attributes, timestamp, source, attachments, metrics, reactions, platforms 
+                        FROM messages 
+                        WHERE id = 'no_match_placeholder'
+                    """)  # This will return 0 matches
             
-            # Execute query and get count
+            # Execute query and get message records
             result = await session.execute(query)
-            count = result.scalar()
+            rows = result.fetchall()
             
-            # Return True if we found any messages
-            return count > 0
+            # Convert rows to MessageRecord objects
+            records = []
+            for row in rows:
+                # Create a MessageRecord from the row (mapping by column order)
+                record = MessageRecord(
+                    id=row[0],
+                    thread_id=row[1], 
+                    sequence=row[2],
+                    role=row[3],
+                    content=row[4],
+                    name=row[5],
+                    tool_call_id=row[6],
+                    tool_calls=row[7],
+                    attributes=row[8],
+                    timestamp=row[9],
+                    source=row[10],
+                    attachments=row[11],
+                    metrics=row[12],
+                    reactions=row[13],
+                    platforms=row[14]
+                )
+                records.append(record)
+            
+            # Log detailed results for debugging
+            if records:
+                logger.info(f"Found {len(records)} messages matching {path}={value}")
+                for idx, record in enumerate(records):
+                    logger.info(f"Match {idx+1}: Message ID {record.id} in thread {record.thread_id}, role={record.role}")
+            else:
+                logger.info(f"No messages found matching {path}={value}")
+            
+            return records
         except Exception as e:
             logger.error(f"Error in find_messages_by_attribute: {str(e)}")
-            return False  # On error, assume no match
+            return []  # Return empty list on error
         finally:
             await session.close()
 

--- a/tyler/database/storage_backend.py
+++ b/tyler/database/storage_backend.py
@@ -10,11 +10,12 @@ import asyncio
 from sqlalchemy import create_engine, select, cast, String, text
 from sqlalchemy.orm import sessionmaker, selectinload
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+# Direct imports
 from tyler.models.thread import Thread
 from tyler.models.message import Message
 from tyler.models.attachment import Attachment
-from tyler.utils.logging import get_logger
 from tyler.storage.file_store import FileStore
+from tyler.utils.logging import get_logger
 from .models import Base, ThreadRecord, MessageRecord
 
 logger = get_logger(__name__)

--- a/tyler/database/storage_backend.py
+++ b/tyler/database/storage_backend.py
@@ -493,7 +493,7 @@ class SQLBackend(StorageBackend):
                             str_value = str(value).lower()
                         
                         # Use PostgreSQL's JSONB operators for direct string comparison
-                        param_name = f"platform_{key}"
+                        param_name = f"platform_{platform_name}_{key}"
                         query = query.where(
                             text(f"platforms->'{platform_name}'->'{key}' = :{param_name}::jsonb")
                             .bindparams(**{param_name: str_value})

--- a/tyler/database/storage_backend.py
+++ b/tyler/database/storage_backend.py
@@ -234,7 +234,8 @@ class SQLBackend(StorageBackend):
             attributes=msg_record.attributes,
             timestamp=msg_record.timestamp,
             source=msg_record.source,
-            metrics=msg_record.metrics
+            metrics=msg_record.metrics,
+            reactions=msg_record.reactions or {}
         )
         if msg_record.attachments:
             message.attachments = [Attachment(**a) for a in msg_record.attachments]
@@ -274,7 +275,8 @@ class SQLBackend(StorageBackend):
             timestamp=message.timestamp,
             source=message.source,
             attachments=[a.model_dump() for a in message.attachments] if message.attachments else None,
-            metrics=message.metrics
+            metrics=message.metrics,
+            reactions=message.reactions
         )
     
     async def _get_session(self) -> AsyncSession:

--- a/tyler/database/thread_store.py
+++ b/tyler/database/thread_store.py
@@ -20,7 +20,7 @@ class ThreadStore:
     
     Usage:
         # RECOMMENDED: Factory pattern for immediate connection validation
-        from tyler.database.thread_store import ThreadStore
+        from tyler import ThreadStore
         store = await ThreadStore.create("postgresql+asyncpg://user:pass@localhost/dbname")
         
         # Or for in-memory storage:

--- a/tyler/models/agent.py
+++ b/tyler/models/agent.py
@@ -1201,8 +1201,7 @@ class Agent(Model):
     def _create_assistant_source(self, include_version: bool = True) -> Dict:
         """Creates a standardized source entity dict for assistant messages."""
         attributes = {
-            "model": self.model_name,
-            "purpose": self.purpose
+            "model": self.model_name
         }
         
         return {

--- a/tyler/models/agent.py
+++ b/tyler/models/agent.py
@@ -584,8 +584,9 @@ class Agent(Model):
         )
         thread.add_message(message)
         new_messages.append(message)
-        if await self._get_thread_store():
-            await self._get_thread_store().save(thread)
+        thread_store = await self._get_thread_store()
+        if thread_store:
+            await thread_store.save(thread)
         return thread, [m for m in new_messages if m.role != "user"]
 
     @weave.op()
@@ -647,8 +648,9 @@ class Agent(Model):
                         thread.add_message(message)
                         new_messages.append(message)
                         # Save on error
-                        if await self._get_thread_store():
-                            await self._get_thread_store().save(thread)
+                        thread_store = await self._get_thread_store()
+                        if thread_store:
+                            await thread_store.save(thread)
                         break
                     
                     # For non-streaming responses, get content and tool calls directly
@@ -758,8 +760,9 @@ class Agent(Model):
                                 should_break = True
                                 
                         # Save after processing all tool calls but before next completion
-                        if await self._get_thread_store():
-                            await self._get_thread_store().save(thread)
+                        thread_store = await self._get_thread_store()
+                        if thread_store:
+                            await thread_store.save(thread)
                             
                         if should_break:
                             break
@@ -788,8 +791,9 @@ class Agent(Model):
                     thread.add_message(message)
                     new_messages.append(message)
                     # Save on error
-                    if await self._get_thread_store():
-                        await self._get_thread_store().save(thread)
+                    thread_store = await self._get_thread_store()
+                    if thread_store:
+                        await thread_store.save(thread)
                     break
                 
             # Handle max iterations if needed
@@ -803,8 +807,9 @@ class Agent(Model):
                 new_messages.append(message)
                 
             # Final save at end of processing
-            if await self._get_thread_store():
-                await self._get_thread_store().save(thread)
+            thread_store = await self._get_thread_store()
+            if thread_store:
+                await thread_store.save(thread)
                 
             return thread, [m for m in new_messages if m.role != "user"]
 
@@ -836,8 +841,9 @@ class Agent(Model):
                 
             thread.add_message(message)
             # Save on error
-            if await self._get_thread_store():
-                await self._get_thread_store().save(thread)
+            thread_store = await self._get_thread_store()
+            if thread_store:
+                await thread_store.save(thread)
             return thread, [message]
 
     @weave.op()
@@ -870,8 +876,9 @@ class Agent(Model):
                 )
                 thread.add_message(message)
                 yield StreamUpdate(StreamUpdate.Type.ASSISTANT_MESSAGE, message)
-                if await self._get_thread_store():
-                    await self._get_thread_store().save(thread)
+                thread_store = await self._get_thread_store()
+                if thread_store:
+                    await thread_store.save(thread)
                 return
 
             while self._iteration_count < self.max_tool_iterations:
@@ -898,8 +905,9 @@ class Agent(Model):
                         new_messages.append(message)
                         yield StreamUpdate(StreamUpdate.Type.ERROR, error_msg)
                         # Save on error like in go
-                        if await self._get_thread_store():
-                            await self._get_thread_store().save(thread)
+                        thread_store = await self._get_thread_store()
+                        if thread_store:
+                            await thread_store.save(thread)
                         break
 
                     # Process streaming response
@@ -1009,8 +1017,9 @@ class Agent(Model):
                     # If no tool calls, we're done
                     if not current_tool_calls:
                         # Save state like in go
-                        if await self._get_thread_store():
-                            await self._get_thread_store().save(thread)
+                        thread_store = await self._get_thread_store()
+                        if thread_store:
+                            await thread_store.save(thread)
                         break
 
                     # Execute tools in parallel and yield results
@@ -1039,8 +1048,9 @@ class Agent(Model):
                                     error_msg = f"Tool execution failed: Invalid JSON in tool arguments: {json_err}"
                                     yield StreamUpdate(StreamUpdate.Type.ERROR, error_msg)
                                     # Save on error
-                                    if await self._get_thread_store():
-                                        await self._get_thread_store().save(thread)
+                                    thread_store = await self._get_thread_store()
+                                    if thread_store:
+                                        await thread_store.save(thread)
                                     # Break out of the inner loop and continue to the next iteration
                                     raise ValueError(error_msg)
 
@@ -1132,8 +1142,9 @@ class Agent(Model):
                                 should_break = True
                         
                         # Save after processing all tool calls but before next completion
-                        if await self._get_thread_store():
-                            await self._get_thread_store().save(thread)
+                        thread_store = await self._get_thread_store()
+                        if thread_store:
+                            await thread_store.save(thread)
                             
                         if should_break:
                             break
@@ -1158,13 +1169,15 @@ class Agent(Model):
                         new_messages.append(error_message)
                         yield StreamUpdate(StreamUpdate.Type.ERROR, error_msg)
                         # Save on error like in go
-                        if await self._get_thread_store():
-                            await self._get_thread_store().save(thread)
+                        thread_store = await self._get_thread_store()
+                        if thread_store:
+                            await thread_store.save(thread)
                         break
 
                     # Save after processing all tool calls but before next completion
-                    if await self._get_thread_store():
-                        await self._get_thread_store().save(thread)
+                    thread_store = await self._get_thread_store()
+                    if thread_store:
+                        await thread_store.save(thread)
                             
                     if should_break:
                         break
@@ -1194,8 +1207,9 @@ class Agent(Model):
                     new_messages.append(error_message)
                     yield StreamUpdate(StreamUpdate.Type.ERROR, error_msg)
                     # Save on error like in go
-                    if await self._get_thread_store():
-                        await self._get_thread_store().save(thread)
+                    thread_store = await self._get_thread_store()
+                    if thread_store:
+                        await thread_store.save(thread)
                     break
 
             # Handle max iterations
@@ -1210,8 +1224,9 @@ class Agent(Model):
                 yield StreamUpdate(StreamUpdate.Type.ASSISTANT_MESSAGE, message)
 
             # Save final state if using thread store
-            if await self._get_thread_store():
-                await self._get_thread_store().save(thread)
+            thread_store = await self._get_thread_store()
+            if thread_store:
+                await thread_store.save(thread)
 
             # Yield final complete update
             new_messages = [m for m in thread.messages if m.role != "user"]
@@ -1235,8 +1250,9 @@ class Agent(Model):
             new_messages.append(error_message)
             yield StreamUpdate(StreamUpdate.Type.ERROR, error_msg)
             # Save on error like in go
-            if await self._get_thread_store():
-                await self._get_thread_store().save(thread)
+            thread_store = await self._get_thread_store()
+            if thread_store:
+                await thread_store.save(thread)
             raise  # Re-raise to ensure error is properly propagated
 
         finally:

--- a/tyler/models/agent.py
+++ b/tyler/models/agent.py
@@ -42,32 +42,41 @@ class StreamUpdate:
         self.data = data
 
 class AgentPrompt(Prompt):
-    system_template: str = Field(default="""Your name is {name} and you are a {model_name} powered AI agent that can converse, answer questions, and when necessary, use tools to perform tasks.
+    system_template: str = Field(default="""<agent_overview>
+# Agent Identity
+Your name is {name} and you are a {model_name} powered AI agent that can converse, answer questions, and when necessary, use tools to perform tasks.
 
 Current date: {current_date}
-                                 
-Your purpose is: 
+
+# Core Purpose
+Your purpose is:
 ```
 {purpose}
 ```
 
+# Supporting Notes
 Here are some relevant notes to help you accomplish your purpose:
 ```
 {notes}
 ```
-                                 
+</agent_overview>
+
+<operational_routine>
+# Operational Routine
 Based on the user's input, follow this routine:
 1. If the user makes a statement or shares information, respond appropriately with acknowledgment.
 2. If the user's request is vague, incomplete, or missing information needed to complete the task, use the relevant notes to understand the user's request. If you don't find an answer in the notes, ask probing questions to understand the user's request deeper. You can ask a maximum of 3 probing questions.
 3. If the request requires gathering information or performing actions beyond your knowledge you can use the tools available to you.
+</operational_routine>
 
-**AVAILABLE TOOLS:**
+<tool_usage_guidelines>
+# Tool Usage Guidelines
 
+## Available Tools
 You have access to the following tools:
 {tools_description}
 
-**IMPORTANT INSTRUCTION ABOUT USING TOOLS:**
-
+## Important Instructions for Using Tools
 When you need to use a tool, you MUST FIRST write a brief message to the user summarizing the user's ask and what you're going to do. This message should be casual and conversational, like talking with a friend. After writing this message, then include your tool call.
 
 For example:
@@ -89,9 +98,10 @@ Assistant: "Let me figure that out for you."
 [Then you would use the calculator tool]
 
 Remember: ALWAYS write a brief, conversational message to the user BEFORE using any tools. Never skip this step. The message should acknowledge what the user is asking for and let them know what you're going to do, but keep it casual and friendly.
+</tool_usage_guidelines>
 
-**HANDLING FILE ATTACHMENTS:**
-
+<file_handling_instructions>
+# File Handling Instructions
 Both user messages and tool responses may contain file attachments. 
 
 File attachments are included in the message content in this format:
@@ -106,7 +116,7 @@ Instead of: "I've created an audio summary. You can listen to it [here](sandbox:
 Use: "I've created an audio summary. You can listen to it [here](files/path/to/stored/file.mp3)."
 
 This ensures the user can access the file correctly.
-""")
+</file_handling_instructions>""")
 
     @weave.op()
     def system_prompt(self, purpose: str, name: str, model_name: str, tools: List[Dict], notes: str = "") -> str:
@@ -131,7 +141,7 @@ This ensures the user can access the file correctly.
         )
 
 class Agent(Model):
-    model_name: str = Field(default="gpt-4o")
+    model_name: str = Field(default="gpt-4.1")
     temperature: float = Field(default=0.7)
     name: str = Field(default="Tyler")
     purpose: str = Field(default="To be a helpful assistant.")

--- a/tyler/models/agent.py
+++ b/tyler/models/agent.py
@@ -364,14 +364,12 @@ class Agent(Model):
                 role='assistant', 
                 content=error_text,
                 source={
-                    "entity": {
-                        "id": self.name,
-                        "name": self.name,
-                        "type": "agent",
-                        "attributes": {
-                            "model": self.model_name,
-                            "purpose": self.purpose
-                        }
+                    "id": self.name,
+                    "name": self.name,
+                    "type": "agent",
+                    "attributes": {
+                        "model": self.model_name,
+                        "purpose": self.purpose
                     }
                 }
             )
@@ -1187,13 +1185,11 @@ class Agent(Model):
     def _create_tool_source(self, tool_name: str) -> Dict:
         """Creates a standardized source entity dict for tool messages."""
         return {
-            "entity": {
-                "id": tool_name,
-                "name": tool_name,
-                "type": "tool",
-                "attributes": {
-                    "agent_id": self.name
-                }
+            "id": tool_name,
+            "name": tool_name,
+            "type": "tool",
+            "attributes": {
+                "agent_id": self.name
             }
         }
 
@@ -1205,10 +1201,8 @@ class Agent(Model):
         }
         
         return {
-            "entity": {
-                "id": self.name,
-                "name": self.name,
-                "type": "agent",
-                "attributes": attributes
-            }
+            "id": self.name,
+            "name": self.name,
+            "type": "agent",
+            "attributes": attributes
         } 

--- a/tyler/models/agent.py
+++ b/tyler/models/agent.py
@@ -7,11 +7,14 @@ from typing import List, Dict, Any, Optional, Union, AsyncGenerator, Tuple
 from datetime import datetime, UTC
 from pydantic import Field, PrivateAttr
 from litellm import acompletion
+
+# Direct imports to avoid circular dependency
 from tyler.models.thread import Thread
 from tyler.models.message import Message
 from tyler.models.attachment import Attachment
 from tyler.database.thread_store import ThreadStore
 from tyler.storage.file_store import FileStore
+
 from tyler.utils.tool_runner import tool_runner
 from tyler.utils.registry import get, register
 from enum import Enum

--- a/tyler/models/attachment.py
+++ b/tyler/models/attachment.py
@@ -106,7 +106,6 @@ class Attachment(BaseModel):
             
             try:
                 # Get the file URL from FileStore
-                from tyler.storage.file_store import FileStore
                 self.attributes["url"] = FileStore.get_file_url(self.storage_path)
                 logger.debug(f"Updated attributes with URL: {self.attributes['url']}")
             except Exception as e:

--- a/tyler/models/message.py
+++ b/tyler/models/message.py
@@ -5,7 +5,8 @@ import hashlib
 import json
 from tyler.utils.logging import get_logger
 import base64
-from .attachment import Attachment
+# Direct imports
+from tyler.models.attachment import Attachment
 from tyler.storage.file_store import FileStore
 
 # Get configured logger

--- a/tyler/models/message.py
+++ b/tyler/models/message.py
@@ -466,7 +466,7 @@ class Message(BaseModel):
                         }
                     ],
                     "metrics": {
-                        "model": "gpt-4o",
+                        "model": "gpt-4.1",
                         "timing": {
                             "started_at": "2024-02-07T00:00:00+00:00",
                             "ended_at": "2024-02-07T00:00:01+00:00",

--- a/tyler/models/message.py
+++ b/tyler/models/message.py
@@ -356,13 +356,16 @@ class Message(BaseModel):
         Returns:
             True if reaction was added, False if it already existed
         """
+        logger.info(f"Message.add_reaction (msg_id={self.id}): Current reactions: {self.reactions}. Adding '{emoji}' for user '{user_id}'.")
         if emoji not in self.reactions:
             self.reactions[emoji] = []
         
         if user_id in self.reactions[emoji]:
-            return False
+            logger.warning(f"Message.add_reaction (msg_id={self.id}): User '{user_id}' already reacted with '{emoji}'.")
+            return False # Indicate that reaction was not newly added because it already existed
         
         self.reactions[emoji].append(user_id)
+        logger.info(f"Message.add_reaction (msg_id={self.id}): Successfully added. Reactions now: {self.reactions}")
         return True
 
     def remove_reaction(self, emoji: str, user_id: str) -> bool:
@@ -375,7 +378,9 @@ class Message(BaseModel):
         Returns:
             True if reaction was removed, False if it didn't exist
         """
+        logger.info(f"Message.remove_reaction (msg_id={self.id}): Current reactions: {self.reactions}. Removing '{emoji}' for user '{user_id}'.")
         if emoji not in self.reactions or user_id not in self.reactions[emoji]:
+            logger.warning(f"Message.remove_reaction (msg_id={self.id}): Emoji '{emoji}' or user '{user_id}' not found in reactions {self.reactions}.")
             return False
         
         self.reactions[emoji].remove(user_id)
@@ -384,6 +389,7 @@ class Message(BaseModel):
         if not self.reactions[emoji]:
             del self.reactions[emoji]
             
+        logger.info(f"Message.remove_reaction (msg_id={self.id}): Successfully removed. Reactions now: {self.reactions}")
         return True
 
     def get_reactions(self) -> Dict[str, List[str]]:

--- a/tyler/models/thread.py
+++ b/tyler/models/thread.py
@@ -15,7 +15,10 @@ class Thread(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     attributes: Dict = Field(default_factory=dict)
-    source: Optional[Dict[str, Any]] = None  # {"name": "slack", "thread_id": "..."}
+    platforms: Dict[str, Dict[str, str]] = Field(
+        default_factory=dict,
+        description="References to where this thread exists on external platforms. Maps platform name to platform-specific identifiers."
+    )
     
     model_config = {
         "json_schema_extra": {
@@ -27,10 +30,11 @@ class Thread(BaseModel):
                     "created_at": "2024-02-07T00:00:00+00:00",
                     "updated_at": "2024-02-07T00:00:00+00:00",
                     "attributes": {},
-                    "source": {
-                        "name": "slack",
+                    "platforms": {
+                        "slack": {
                         "channel": "C123",
                         "thread_ts": "1234567890.123"
+                        }
                     }
                 }
             ]
@@ -59,7 +63,7 @@ class Thread(BaseModel):
             "created_at": self.created_at.isoformat() if mode == "json" else self.created_at,
             "updated_at": self.updated_at.isoformat() if mode == "json" else self.updated_at,
             "attributes": self.attributes,
-            "source": self.source
+            "platforms": self.platforms
         }
     
     def add_message(self, message: Message) -> None:

--- a/tyler/models/thread.py
+++ b/tyler/models/thread.py
@@ -6,6 +6,9 @@ from tyler.storage.file_store import FileStore
 from litellm import completion
 import uuid
 import weave
+from tyler.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 class Thread(BaseModel):
     """Represents a thread containing multiple messages"""
@@ -319,9 +322,14 @@ class Thread(BaseModel):
         """
         message = self.get_message_by_id(message_id)
         if not message:
+            logger.warning(f"Thread.add_reaction (thread_id={self.id}): Message with ID '{message_id}' not found.")
             return False
-            
-        return message.add_reaction(emoji, user_id)
+        
+        result = message.add_reaction(emoji, user_id)
+        if result:
+            self.updated_at = datetime.now(UTC) # Ensure thread update time is changed
+            logger.info(f"Thread.add_reaction (thread_id={self.id}): Message '{message_id}' reactions updated. Thread updated_at: {self.updated_at}")
+        return result
     
     def remove_reaction(self, message_id: str, emoji: str, user_id: str) -> bool:
         """Remove a reaction from a message in the thread
@@ -336,9 +344,14 @@ class Thread(BaseModel):
         """
         message = self.get_message_by_id(message_id)
         if not message:
+            logger.warning(f"Thread.remove_reaction (thread_id={self.id}): Message with ID '{message_id}' not found.")
             return False
             
-        return message.remove_reaction(emoji, user_id)
+        result = message.remove_reaction(emoji, user_id)
+        if result:
+            self.updated_at = datetime.now(UTC) # Ensure thread update time is changed
+            logger.info(f"Thread.remove_reaction (thread_id={self.id}): Message '{message_id}' reactions updated. Thread updated_at: {self.updated_at}")
+        return result
     
     def get_reactions(self, message_id: str) -> Dict[str, List[str]]:
         """Get all reactions for a message in the thread

--- a/tyler/models/thread.py
+++ b/tyler/models/thread.py
@@ -104,7 +104,7 @@ class Thread(BaseModel):
         
     @weave.op()
     def generate_title(self) -> str:
-        """Generate a concise title for the thread using GPT-4o"""
+        """Generate a concise title for the thread using GPT-4.1"""
         if not self.messages:
             return "Empty Thread"
         
@@ -121,7 +121,7 @@ class Thread(BaseModel):
         ]
         
         response = completion(
-            model="gpt-4o",
+            model="gpt-4.1",
             messages=messages,
             temperature=0.7,
             max_tokens=50

--- a/tyler/models/thread.py
+++ b/tyler/models/thread.py
@@ -294,3 +294,59 @@ class Thread(BaseModel):
     def get_messages_in_sequence(self) -> List[Message]:
         """Get messages sorted by sequence number"""
         return sorted(self.messages, key=lambda m: m.sequence if m.sequence is not None else float('inf'))
+
+    def get_message_by_id(self, message_id: str) -> Optional[Message]:
+        """Return the message with the specified ID, or None if no message exists with that ID"""
+        for message in self.messages:
+            if message.id == message_id:
+                return message
+        return None
+
+    def add_reaction(self, message_id: str, emoji: str, user_id: str) -> bool:
+        """Add a reaction to a message in the thread
+        
+        Args:
+            message_id: ID of the message to react to
+            emoji: Emoji shortcode (e.g., ":thumbsup:")
+            user_id: ID of the user adding the reaction
+            
+        Returns:
+            True if reaction was added, False if it wasn't (message not found or already reacted)
+        """
+        message = self.get_message_by_id(message_id)
+        if not message:
+            return False
+            
+        return message.add_reaction(emoji, user_id)
+    
+    def remove_reaction(self, message_id: str, emoji: str, user_id: str) -> bool:
+        """Remove a reaction from a message in the thread
+        
+        Args:
+            message_id: ID of the message to remove reaction from
+            emoji: Emoji shortcode (e.g., ":thumbsup:")
+            user_id: ID of the user removing the reaction
+            
+        Returns:
+            True if reaction was removed, False if it wasn't (message or reaction not found)
+        """
+        message = self.get_message_by_id(message_id)
+        if not message:
+            return False
+            
+        return message.remove_reaction(emoji, user_id)
+    
+    def get_reactions(self, message_id: str) -> Dict[str, List[str]]:
+        """Get all reactions for a message in the thread
+        
+        Args:
+            message_id: ID of the message to get reactions for
+            
+        Returns:
+            Dictionary mapping emoji to list of user IDs, or empty dict if message not found
+        """
+        message = self.get_message_by_id(message_id)
+        if not message:
+            return {}
+            
+        return message.get_reactions()

--- a/tyler/tools/browser.py
+++ b/tyler/tools/browser.py
@@ -19,7 +19,7 @@ load_dotenv()
 @weave.op(name="browser-automate")
 async def browser_automate(*, 
                           task: str, 
-                          model: str = "gpt-4o",
+                          model: str = "gpt-4.1",
                           headless: bool = False,  # Default to non-headless mode so users can see the browser
                           timeout: int = 300) -> Dict[str, Any]:
     """
@@ -27,7 +27,7 @@ async def browser_automate(*,
     
     Args:
         task (str): The task to perform in natural language (e.g., "Go to google.com and search for Browser Use")
-        model (str): The model to use for the browser agent (default: "gpt-4o")
+        model (str): The model to use for the browser agent (default: "gpt-4.1")
         headless (bool): Whether to run the browser in headless mode (default: False)
         timeout (int): Maximum time in seconds to run the task (default: 300)
         
@@ -124,7 +124,7 @@ async def browser_screenshot(*,
         task = f"Go to {url} and take a {'full page' if full_page else 'viewport'} screenshot"
         
         # Initialize the browser agent
-        llm = ChatOpenAI(model="gpt-4o")
+        llm = ChatOpenAI(model="gpt-4.1")
         
         agent = BrowserAgent(
             task=task,
@@ -184,7 +184,7 @@ TOOLS = [
                         },
                         "model": {
                             "type": "string",
-                            "description": "The model to use for the browser agent (default: 'gpt-4o')"
+                            "description": "The model to use for the browser agent (default: 'gpt-4.1')"
                         },
                         "headless": {
                             "type": "boolean",

--- a/tyler/tools/files.py
+++ b/tyler/tools/files.py
@@ -147,7 +147,7 @@ class Files:
                 
                 # Process with Vision API
                 response = completion(
-                    model="gpt-4o",
+                    model="gpt-4.1",
                     messages=[
                         {
                             "role": "user",

--- a/tyler/tools/image.py
+++ b/tyler/tools/image.py
@@ -166,7 +166,7 @@ async def analyze_image(*,
         
         # Call vision API using litellm
         response = completion(
-            model="gpt-4o",
+            model="gpt-4.1",
             messages=messages
         )
         

--- a/tyler/tools/slack.py
+++ b/tyler/tools/slack.py
@@ -90,7 +90,7 @@ async def generate_slack_blocks(*, content: str) -> dict:
     try:
         # Use the async version of litellm.completion
         response = await litellm.acompletion(
-            model="gpt-4o",
+            model="gpt-4.1",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.7,
             response_format={"type": "json_object"}

--- a/tyler/utils/agent_runner.py
+++ b/tyler/utils/agent_runner.py
@@ -7,6 +7,7 @@ import asyncio
 import weave
 from typing import Dict, Any, Optional, List, Tuple
 from datetime import datetime, UTC
+# Direct imports
 from tyler.models.thread import Thread
 from tyler.models.message import Message
 from tyler.utils.logging import get_logger

--- a/tyler/utils/registry.py
+++ b/tyler/utils/registry.py
@@ -134,48 +134,4 @@ def get_file_store(name: str) -> Optional["FileStore"]:
     Returns:
         The file store instance or None if not found
     """
-    return get("file_store", name)
-
-# Combined operations
-def register_stores(name: str, thread_store: "ThreadStore", file_store: "FileStore") -> Tuple["ThreadStore", "FileStore"]:
-    """Register both thread and file stores with the same name.
-    
-    This is a convenience function for the common case where both stores
-    share the same name identifier.
-    
-    Args:
-        name: Name identifier for both stores
-        thread_store: The thread store instance
-        file_store: The file store instance
-        
-    Returns:
-        Tuple of (thread_store, file_store)
-    """
-    register_thread_store(name, thread_store)
-    register_file_store(name, file_store)
-    return thread_store, file_store
-
-async def create_stores(name: str, thread_store_url: Optional[str] = None, 
-                        file_store_path: Optional[str] = None) -> Tuple["ThreadStore", "FileStore"]:
-    """Create and register both thread and file stores.
-    
-    This is a convenience function for creating and registering stores in one step.
-    
-    Args:
-        name: Name identifier for both stores
-        thread_store_url: Database URL for thread store (optional)
-        file_store_path: Path for file store (optional)
-        
-    Returns:
-        Tuple of (thread_store, file_store)
-    """
-    # Import here to avoid circular dependencies
-    from tyler.database.thread_store import ThreadStore
-    from tyler.storage.file_store import FileStore
-    
-    # Create stores
-    thread_store = await ThreadStore.create(thread_store_url)
-    file_store = await FileStore.create(file_store_path)
-    
-    # Register stores
-    return register_stores(name, thread_store, file_store) 
+    return get("file_store", name) 

--- a/tyler/utils/registry.py
+++ b/tyler/utils/registry.py
@@ -4,8 +4,7 @@ import logging
 
 # Type hints with conditional imports to avoid circular dependencies
 if TYPE_CHECKING:
-    from tyler.database.thread_store import ThreadStore
-    from tyler.storage.file_store import FileStore
+    from tyler import ThreadStore, FileStore
     
 logger = logging.getLogger(__name__)
 

--- a/tyler/utils/registry.py
+++ b/tyler/utils/registry.py
@@ -1,0 +1,84 @@
+"""Component registry for managing shared resources."""
+from typing import Any, Dict, Tuple, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Registry:
+    """Registry for managing shared components like thread stores and file stores.
+    
+    This registry ensures components have stable identity across multiple
+    agent initializations.
+    """
+    
+    # Singleton instance of the registry
+    _instance = None
+    
+    # Dictionary to store registered components
+    _components: Dict[Tuple[str, str], Any] = {}
+    
+    @classmethod
+    def get_instance(cls) -> 'Registry':
+        """Get the singleton instance of the registry."""
+        if cls._instance is None:
+            cls._instance = Registry()
+        return cls._instance
+    
+    def register(self, component_type: str, name: str, instance: Any) -> Any:
+        """Register a component in the registry.
+        
+        Args:
+            component_type: Type of component (e.g., "thread_store", "file_store")
+            name: Name identifier for the component
+            instance: The component instance to register
+            
+        Returns:
+            The registered instance
+        """
+        key = (component_type, name)
+        self._components[key] = instance
+        logger.debug(f"Registered {component_type} with name '{name}'")
+        return instance
+    
+    def get(self, component_type: str, name: str) -> Optional[Any]:
+        """Get a component from the registry.
+        
+        Args:
+            component_type: Type of component to retrieve
+            name: Name identifier of the component
+            
+        Returns:
+            The component instance or None if not found
+        """
+        key = (component_type, name)
+        component = self._components.get(key)
+        if component is None:
+            logger.debug(f"Component {component_type} with name '{name}' not found")
+        return component
+    
+    def list(self, component_type: Optional[str] = None) -> Dict[Tuple[str, str], Any]:
+        """List all registered components, optionally filtered by type.
+        
+        Args:
+            component_type: Optional type to filter components by
+            
+        Returns:
+            Dictionary of components
+        """
+        if component_type is None:
+            return self._components.copy()
+        
+        return {k: v for k, v in self._components.items() if k[0] == component_type}
+
+# Convenience functions for working with the registry
+def register(component_type: str, name: str, instance: Any) -> Any:
+    """Register a component in the global registry."""
+    return Registry.get_instance().register(component_type, name, instance)
+
+def get(component_type: str, name: str) -> Optional[Any]:
+    """Get a component from the global registry."""
+    return Registry.get_instance().get(component_type, name)
+
+def list(component_type: Optional[str] = None) -> Dict[Tuple[str, str], Any]:
+    """List components in the global registry."""
+    return Registry.get_instance().list(component_type) 

--- a/tyler/utils/registry.py
+++ b/tyler/utils/registry.py
@@ -1,7 +1,12 @@
 """Component registry for managing shared resources."""
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional, TYPE_CHECKING
 import logging
 
+# Type hints with conditional imports to avoid circular dependencies
+if TYPE_CHECKING:
+    from tyler.database.thread_store import ThreadStore
+    from tyler.storage.file_store import FileStore
+    
 logger = logging.getLogger(__name__)
 
 class Registry:
@@ -70,7 +75,7 @@ class Registry:
         
         return {k: v for k, v in self._components.items() if k[0] == component_type}
 
-# Convenience functions for working with the registry
+# Basic registry functions
 def register(component_type: str, name: str, instance: Any) -> Any:
     """Register a component in the global registry."""
     return Registry.get_instance().register(component_type, name, instance)
@@ -81,4 +86,96 @@ def get(component_type: str, name: str) -> Optional[Any]:
 
 def list(component_type: Optional[str] = None) -> Dict[Tuple[str, str], Any]:
     """List components in the global registry."""
-    return Registry.get_instance().list(component_type) 
+    return Registry.get_instance().list(component_type)
+
+# Thread store specific functions
+def register_thread_store(name: str, thread_store: "ThreadStore") -> "ThreadStore":
+    """Register a thread store with the given name.
+    
+    Args:
+        name: Name identifier for the thread store
+        thread_store: The thread store instance
+        
+    Returns:
+        The registered thread store
+    """
+    return register("thread_store", name, thread_store)
+
+def get_thread_store(name: str) -> Optional["ThreadStore"]:
+    """Get a thread store by name.
+    
+    Args:
+        name: Name of the thread store
+        
+    Returns:
+        The thread store instance or None if not found
+    """
+    return get("thread_store", name)
+
+# File store specific functions
+def register_file_store(name: str, file_store: "FileStore") -> "FileStore":
+    """Register a file store with the given name.
+    
+    Args:
+        name: Name identifier for the file store
+        file_store: The file store instance
+        
+    Returns:
+        The registered file store
+    """
+    return register("file_store", name, file_store)
+
+def get_file_store(name: str) -> Optional["FileStore"]:
+    """Get a file store by name.
+    
+    Args:
+        name: Name of the file store
+        
+    Returns:
+        The file store instance or None if not found
+    """
+    return get("file_store", name)
+
+# Combined operations
+def register_stores(name: str, thread_store: "ThreadStore", file_store: "FileStore") -> Tuple["ThreadStore", "FileStore"]:
+    """Register both thread and file stores with the same name.
+    
+    This is a convenience function for the common case where both stores
+    share the same name identifier.
+    
+    Args:
+        name: Name identifier for both stores
+        thread_store: The thread store instance
+        file_store: The file store instance
+        
+    Returns:
+        Tuple of (thread_store, file_store)
+    """
+    register_thread_store(name, thread_store)
+    register_file_store(name, file_store)
+    return thread_store, file_store
+
+async def create_stores(name: str, thread_store_url: Optional[str] = None, 
+                        file_store_path: Optional[str] = None) -> Tuple["ThreadStore", "FileStore"]:
+    """Create and register both thread and file stores.
+    
+    This is a convenience function for creating and registering stores in one step.
+    
+    Args:
+        name: Name identifier for both stores
+        thread_store_url: Database URL for thread store (optional)
+        file_store_path: Path for file store (optional)
+        
+    Returns:
+        Tuple of (thread_store, file_store)
+    """
+    # Import here to avoid circular dependencies
+    from tyler.database.thread_store import ThreadStore
+    from tyler.storage.file_store import FileStore
+    
+    # Create stores
+    thread_store = await ThreadStore.create(thread_store_url)
+    file_store = await FileStore.create(file_store_path)
+    
+    # Register stores
+    return register_stores(name, thread_store, file_store) 

--- a/tyler/utils/tool_runner.py
+++ b/tyler/utils/tool_runner.py
@@ -9,6 +9,7 @@ import json
 import asyncio
 from functools import wraps
 from tyler.utils.logging import get_logger
+# Direct import
 from tyler.models.attachment import Attachment
 import base64
 


### PR DESCRIPTION
This pull request introduces significant updates to the Tyler documentation and code examples, consolidating imports for simplicity and adding extensive support for emoji reactions in threads and messages. The most important changes include transitioning to a simplified import structure, documenting database migration processes, and enhancing the `Message` and `Thread` classes with reaction-related functionality.

### Simplified Import Structure
* Consolidated imports across examples to use `from tyler import ...` instead of importing from submodules like `tyler.models` or `tyler.storage`. This change simplifies the API for end users. (`README.md`, `docs/api-reference/agent.md`, `docs/api-reference/attachment.md`, `docs/api-reference/file-store.md`, `docs/api-reference/thread.md`, `docs/api-reference/thread-store.md`, `docs/api-reference/message.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L257-R257) [[2]](diffhunk://#diff-70dc8f1689ab2e1cd6ca15e77b1cd91529a77a49407ad339749b98f521f660c7L12-R12) [[3]](diffhunk://#diff-e34ec8a0cadc6f801499d0fd65b7dffb2122e425f61acce2e850ff416e9e660aL12-R12) [[4]](diffhunk://#diff-2e69e34b15288ae98d6e4aeb4ec7daebd1c4668d0f849253d2ed4e39e005d29dL14-R14) [[5]](diffhunk://#diff-2f5738754c3bb2708b3ecb60a125b506dd85c5f79d43412fa0f1dd86c9194e3bL12-R12) [[6]](diffhunk://#diff-63901e1f9829992bc1c38d3b6f37df94a8deb57a469deb0a7ad40cb408da086eL12-R12) [[7]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceL12-R12)

### Database Migrations Documentation
* Added a new `docs/database-migrations.md` file detailing how to manage database migrations in Tyler, including CLI commands, programmatic API usage, and troubleshooting tips.

### Reaction Support in Messages
* Enhanced the `Message` class to support Slack-like emoji reactions, including methods to add, remove, and retrieve reactions (`add_reaction`, `remove_reaction`, `get_reactions`, `get_reaction_counts`). Reactions are serialized as part of the message metadata. (`docs/api-reference/message.md`) [[1]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceR91) [[2]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceR150-R159) [[3]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceL178-R190) [[4]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceR266-R363) [[5]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceR446-R489) [[6]](diffhunk://#diff-58fa9cb5ba355910d465b3cadcbd33a6cbd13c8287995581422ac34dc9788fceR649-R724)

### Reaction Management in Threads
* Introduced methods in the `Thread` class to manage reactions at the thread level, including `add_reaction`, `remove_reaction`, and `get_reactions`. These methods enable centralized reaction handling for messages within a thread. (`docs/api-reference/thread.md`)

### Reaction Persistence in ThreadStore
* Updated `ThreadStore` documentation to describe how reactions are stored and retrieved as part of thread metadata. This ensures reactions are preserved across save and load operations. (`docs/api-reference/thread-store.md`)